### PR TITLE
Add `--install-dependencies` parameter to OVA generation

### DIFF
--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -11,7 +11,7 @@ INDEXES=("wazuh-alerts-*" "wazuh-archives-*" "wazuh-states-vulnerabilities-*" "w
 CURRENT_PATH="$( cd $(dirname $0) ; pwd -P )"
 ASSETS_PATH="${CURRENT_PATH}/assets"
 CUSTOM_PATH="${ASSETS_PATH}/custom"
-INSTALL_ARGS="-a"
+INSTALL_ARGS="-a --install-dependencies"
 
 if [[ "${DEBUG}" = "yes" ]]; then
   INSTALL_ARGS+=" -v"


### PR DESCRIPTION
# Description

This issue aims to include the changes from the PRs done to the `master` branch in the `wazuh-packages` related to the OVA files.

## Issues related

- #59 
- https://github.com/wazuh/wazuh-packages/issues/2879
- 
## PRs related

- https://github.com/wazuh/wazuh-packages/pull/3003
