### PR TITLE
Add a new input for wazuh-virtual-machines reference to the OVA and AMI workflows

### DIFF
--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Checkout wazuh/wazuh-virtual-machines repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.WAZUH_VIRTUAL_MACHINES_REFERENCE}}
+          ref: ${{ inputs.WAZUH_VIRTUAL_MACHINES_REFERENCE }}
 
       - name: Setting FILENAME var
         run: |

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout wazuh/wazuh-virtual-machines repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.WAZUH_VIRTUAL_MACHINES_REFERENCE}}
+          ref: ${{ inputs.WAZUH_VIRTUAL_MACHINES_REFERENCE }}
 
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3


### PR DESCRIPTION
# Description

This PR aims to add a new `WAZUH_VIRTUAL_MACHINES_REFERENCE` input to the OVA and AMI workflows.

## Tests

- Running the `Build OVA` workflow:
![Captura de pantalla 2024-10-08 a las 12 49 05](https://github.com/user-attachments/assets/c45795ad-b6cf-46ad-bc7b-8e4dea1ebafc)

- Running the `Build AMI` workflow:
![Captura de pantalla 2024-10-08 a las 12 49 39](https://github.com/user-attachments/assets/d99b1a43-34f4-495e-bc4a-3c1e321beadd)

## Related issue

- #68 

closes #68 