### PR TITLE
Add validation in the `generate_ova.sh` file when use tag instead a branch reference 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Add validation in the generate_ova.sh file when use tag instead a branch reference ([#100](https://github.com/wazuh/wazuh-virtual-machines/pull/100))
 - Added ova extension to the sha file and change S3 directory from OVA to ova ([#96](https://github.com/wazuh/wazuh-virtual-machines/pull/96))
 - Added # to the Port 22 configuration in the AMI instance ([#97](https://github.com/wazuh/wazuh-virtual-machines/pull/97))
 - Changed GitHub Runner version to fix Python error ([#82](https://github.com/wazuh/wazuh-virtual-machines/pull/82))

--- a/ova/generate_ova.sh
+++ b/ova/generate_ova.sh
@@ -219,6 +219,11 @@ main() {
 
     if [ -z "${INSTALLATION_ASSISTANT_BRANCH}" ]; then
         INSTALLATION_ASSISTANT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+        # If the reference is HEAD, get the tag name
+        if [ "${INSTALLATION_ASSISTANT_BRANCH}" == "HEAD" ]; then
+            INSTALLATION_ASSISTANT_BRANCH=$(git name-rev --tags --name-only $(git rev-parse HEAD))
+        fi
     fi
     if [ "${INSTALLATION_ASSISTANT_BRANCH:0:1}" == "v" ]; then
         REMOTE_TYPE="--tags"


### PR DESCRIPTION
# Description

Previously, when calling `generate_ova.sh` from a tag instead of a branch, the reference to the installation assistant repository was always `HEAD`. This gave an error causing the correct reference not to be found.

A validation has been added where, if you are running the script from a tag, get the correct value (e.g. `v4.10.0` instead of `HEAD` if you are running from the `v4.10.0` tag).

# Tests

- Use the correct tag in the wazuh-installation-assistant repository
```console
$ ./generate_ova.sh -r dev
Building Wazuh OVA version 4.10.0
Cloning Wazuh installation assistant repository
Using v4.10.0-alpha2 branch of wazuh-installation-assistant repository
Building Wazuh installation assistant from v4.10.0-alpha2 branch
Version to build: 4.10.0 with development repository
```

- When the OVA is generated, we can access it successfully.
![Screenshot_20241024_172249](https://github.com/user-attachments/assets/de3f617c-73bf-47e2-83ea-0a17231b5b3f)


## Related issue

- #99 