### PR TITLE
Added venv to AMI and OVA workflows

### DIFF
--- a/.github/workflows/ansible_playbooks/ova_generator.yaml
+++ b/.github/workflows/ansible_playbooks/ova_generator.yaml
@@ -3,9 +3,7 @@
 
   tasks:
     - name: Install git
-      yum:
-        name: git
-        state: present
+      shell: sudo yum install -y git
 
     - name: Make build directory
       file:

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -217,6 +217,10 @@ jobs:
           builder_args='$builder_args' \
           debug=yes" ${{ inputs.DEBUG }}
 
+      - name: Uninstall Python3 from the instance
+        run: |
+          sshpass -p ${{ env.OVA_USER_PASSWORD }} ssh -o 'StrictHostKeyChecking no' ${{ env.OVA_USER }}@${{ env.ANSIBLE_HOST }} "sudo yum remove -y python3"
+
       - name: Export Instance to create OVA
         run: |
           EXPORT=$(aws ec2 create-instance-export-task --instance-id "${{ env.INSTANCE_ID }}" --target-environment vmware \

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -82,10 +82,23 @@ permissions:
 
 jobs:
   build_and_run:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
+      - name: Install Python and create virtual environment
+        run: |
+          sudo apt-get update
+          sudo apt install -y python3 python3-venv
+          python3 -m venv ova_venv
+          source ova_venv/bin/activate
+          python3 -m pip install --upgrade pip
+          echo PATH=$PATH >> $GITHUB_ENV
+
       - name: Install Ansible
-        run: sudo apt-get update && sudo apt install -y python3 jq sshpass && python3 -m pip install --user ansible-core==2.16 && pip install pyyaml && ansible-galaxy collection install community.general
+        run: |
+          sudo apt install -y jq sshpass
+          python3 -m pip install ansible-core==2.16
+          pip install pyyaml
+          ansible-galaxy collection install community.general
 
       - name: Checkout wazuh/wazuh-virtual-machines repository
         uses: actions/checkout@v4
@@ -186,6 +199,10 @@ jobs:
               exit 1
             fi
           done
+
+      - name: Install Python3 in the instance
+        run: |
+          sshpass -p ${{ env.OVA_USER_PASSWORD }} ssh -o 'StrictHostKeyChecking no' ${{ env.OVA_USER }}@${{ env.ANSIBLE_HOST }} "sudo yum install -y python3"
 
       - name: Run Ansible playbook to generate the OVA
         run: |

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -58,7 +58,7 @@ permissions:
 
 jobs:
   Build_AMI:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: View parameters
         run: echo "${{ toJson(inputs) }}"
@@ -79,8 +79,18 @@ jobs:
             WAZUH_VERSION=$(cat VERSION)
             echo WAZUH_VERSION=$WAZUH_VERSION >> $GITHUB_ENV
 
+      - name: Install Python and create virtual environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3 python3-pip
+          python3 -m venv ami_env
+          source ami_env/bin/activate
+          python3 -m pip install --upgrade pip
+          echo PATH=$PATH >> $GITHUB_ENV
+
       - name: Install Ansible
-        run: sudo apt-get update && sudo apt install -y python3 && python3 -m pip install --user ansible-core==2.16
+        run: |
+          python3 -m pip install ansible-core==2.16
 
       - name: Ansible version
         run: ansible --version
@@ -95,7 +105,7 @@ jobs:
 
       - name: Install and set allocator requirements
         run: |
-          pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+          python3 -m pip install -r wazuh-automation/deployability/deps/requirements.txt
 
       - name: Execute allocator module that will create the base instance
         id: alloc_vm_ami

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Added venv to AMI and OVA workflows. ([#112](https://github.com/wazuh/wazuh-virtual-machines/pull/112))
 - Improvements to AMI customization script. ([#98](https://github.com/wazuh/wazuh-virtual-machines/pull/98))
 
 ### Fixed


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-virtual-machines/issues/79

# Description
The aim of this PR is to fix the error that the Github Actions runners were giving due to be updated to a newer version of Ubuntu as we were using the `ubuntu-latest` runners.

In order to keep using the `ubuntu-latest` runners, as we consider this to be the right way of work, we needed to use the Python virtual envinronments called `venvs`. With `venvs`, we can create isolated environments that don’t interfere with the system's Python modules, making it the safest option.

To achieve this, we had to modify the AMI and OVA workflows.

## Tests
Both workflows have been tested and finished with success:
- [AMI workflow](https://github.com/wazuh/wazuh-virtual-machines/actions/runs/11700995580/job/32586144537)
- [OVA workflow](https://github.com/wazuh/wazuh-virtual-machines/actions/runs/11700973815/job/32586080530)