### PR TITLE
Change ami and ova workflows input upper_case to lower_case

### DIFF
--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -8,15 +8,15 @@ on:
         description: "ID used to identify the workflow uniquely."
         type: string
         required: false
-      WAZUH_VIRTUAL_MACHINES_REFERENCE:
+      wazuh_virtual_machines_reference:
         description: 'Branch or tag of the wazuh-virtual-machines repository'
         required: true
         default: '4.10.0'
-      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+      wazuh_installation_assistant_reference:
         description: 'Branch or tag of the wazuh-installation-assistant repository'
         required: true
         default: '4.10.0'
-      WAZUH_PACKAGE_REPOSITORY:
+      wazuh_package_repository:
         type: choice
         description: 'Wazuh package repository from which to download the packages'
         required: true
@@ -24,11 +24,6 @@ on:
           - prod
           - dev
           - staging
-      OVA_REVISION:
-        type: string
-        description: 'Revision of the OVA file. Use "0" for development builds'
-        required: true
-        default: '0'
       is_stage:
         description: "Is stage?"
         type: boolean
@@ -39,7 +34,7 @@ on:
           Generate package checksum.
           Default is 'false'.
         required: false
-      DEBUG:
+      debug:
         type: choice
         description: 'Debug mode'
         required: false
@@ -90,14 +85,14 @@ jobs:
       - name: Checkout wazuh/wazuh-virtual-machines repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.WAZUH_VIRTUAL_MACHINES_REFERENCE }}
+          ref: ${{ inputs.wazuh_virtual_machines_reference }}
 
       - name: Setting FILENAME var
         run: |
           WAZUH_VERSION=$(cat VERSION)
           COMMIT_SHA=$(git rev-parse --short ${{ github.sha }})
           echo "WAZUH_VERSION=$WAZUH_VERSION" >> $GITHUB_ENV
-          FILENAME="wazuh-${WAZUH_VERSION}-${{ inputs.OVA_REVISION }}"
+          FILENAME="wazuh-${WAZUH_VERSION}"
 
           if [ ${{ inputs.is_stage }} == false ]; then
             FILENAME="${FILENAME}-${COMMIT_SHA}"
@@ -192,13 +187,13 @@ jobs:
           builder_args="-i"
           ANSIBLE_STDOUT_CALLBACK=$ANSIBLE_CALLBACK ansible-playbook -i ${{ env.INVENTORY_PATH }}/inventory .github/workflows/ansible_playbooks/ova_generator.yaml \
           --extra-vars " \
-          wia_branch=${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }} \
-          repository=${{ inputs.WAZUH_PACKAGE_REPOSITORY }}  \
+          wia_branch=${{ inputs.wazuh_installation_assistant_reference }} \
+          repository=${{ inputs.wazuh_package_repository }}  \
           ova_path=${{ env.OVA_PATH }} \
           wia_scripts=${{ env.WIA_DIR }} \
           wia_repository=${{ env.WIA_REPOSITORY }} \
           builder_args='$builder_args' \
-          debug=yes" ${{ inputs.DEBUG }}
+          debug=yes" ${{ inputs.debug }}
 
       - name: Export Instance to create OVA
         run: |

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -8,19 +8,19 @@ on:
         description: "ID used to identify the workflow uniquely."
         type: string
         required: false
-      WAZUH_VIRTUAL_MACHINES_REFERENCE:
+      wazuh_virtual_machines_reference:
         description: 'Branch or tag of the wazuh-virtual-machines repository'
         required: true
         default: '4.10.0'
-      WAZUH_AUTOMATION_REFERENCE:
+      wazuh_automation_reference:
         description: 'Branch or tag of the wazuh-automation repository'
         required: true
         default: '4.10.0'
-      WAZUH_INSTALLATION_ASSISTANT_REFERENCE:
+      wazuh_installation_assistant_reference:
         description: 'Branch or tag of the wazuh-installation-assistant repository'
         required: true
         default: '4.10.0'
-      VERBOSITY:
+      verbosity:
         description: 'Verbosity level on playbooks execution'
         required: true
         default: '-v'
@@ -30,13 +30,13 @@ on:
           - -vv
           - -vvv
           - -vvvv
-      AMI_REVISION:
+      ami_revision:
         description: |
           'For AMI candidates must be a number, e,g: -1.'
           'To build a development AMI, use another revision format, e.g: -dev'
         required: false
         default: '-1'
-      DESTROY:
+      destroy:
         type: boolean
         description: 'Destroy the base instance after the AMI is created'
         required: false
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout wazuh/wazuh-virtual-machines repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.WAZUH_VIRTUAL_MACHINES_REFERENCE }}
+          ref: ${{ inputs.wazuh_virtual_machines_reference }}
 
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: wazuh/wazuh-automation
-          ref: ${{ inputs.WAZUH_AUTOMATION_REFERENCE }}
+          ref: ${{ inputs.wazuh_automation_reference }}
           token: ${{ secrets.GH_CLONE_TOKEN }}
           path: wazuh-automation
 
@@ -122,7 +122,7 @@ jobs:
 
       - name: Run Ansible playbook to install Wazuh components
         run: |
-          ansible-playbook -i ${{ env.ALLOCATOR_PATH }}/inventory_ansible.ini ${{ env.PLAYBOOKS_PATH }}/build_ami_packages.yaml --extra-vars "installation_assistant_reference=${{ inputs.WAZUH_INSTALLATION_ASSISTANT_REFERENCE }}" ${{ inputs.VERBOSITY }}
+          ansible-playbook -i ${{ env.ALLOCATOR_PATH }}/inventory_ansible.ini ${{ env.PLAYBOOKS_PATH }}/build_ami_packages.yaml --extra-vars "installation_assistant_reference=${{ inputs.wazuh_installation_assistant_reference }}" ${{ inputs.verbosity }}
 
       - name: Stop instance
         run: |
@@ -157,7 +157,7 @@ jobs:
       - name: Build AMI from instance
         if: success()
         run: |
-          AMI_NAME="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.AMI_REVISION }}"
+          AMI_NAME="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.ami_revision }}"
           aws ec2 create-image --instance-id ${{ env.identifier }} --name "$AMI_NAME" --no-reboot
           AMI_ID=$(aws ec2 describe-images --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].ImageId' --output text)
           echo "AMI_ID=$AMI_ID" >> $GITHUB_ENV
@@ -192,15 +192,15 @@ jobs:
       - name: Tag AMI
         if: success()
         run: |
-          aws ec2 create-tags --resources ${{ env.AMI_ID }} --tags Key=Name,Value="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.AMI_REVISION }}"
+          aws ec2 create-tags --resources ${{ env.AMI_ID }} --tags Key=Name,Value="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.ami_revision }}"
 
       - name: Delete allocated VM
-        if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.DESTROY == true
+        if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.destroy == true
         run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output ${{ env.ALLOCATOR_PATH }}/track.yml
 
       - name: Compress Allocator directory
         id: generate_artifacts
-        if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.DESTROY == false
+        if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.destroy == false
         run: zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r ${{ env.ALLOCATOR_PATH }}.zip ${{ env.ALLOCATOR_PATH }}
         continue-on-error: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Change ami and ova workflows input upper_case to lower_case ([#114](https://github.com/wazuh/wazuh-virtual-machines/pull/114))
 - Changed the SSH port of the AMI to 22 ([#83](https://github.com/wazuh/wazuh-virtual-machines/pull/83))
 - Migrated certificates and passwords changes for AMI. ([#73](https://github.com/wazuh/wazuh-virtual-machines/pull/73))
 - Add a new input for wazuh-virtual-machines reference to the OVA and AMI workflows ([#70](https://github.com/wazuh/wazuh-virtual-machines/pull/70))


### PR DESCRIPTION
# Description

Previously, in the `workflow_dispatch` of the OVA and AMI build workflows, inputs in upper_case were used. In order to follow a standard in the format of the inputs with the rest of the workflows, the style has been changed to lower_case.

## Testing

Tests have been performed on both workflows to verify that everything is still working as expected. In the AMI workflow it has been completely executed and in the OVA workflow it has been stopped from the steps that did not use the inputs.
Both workflows have been executed correctly.

- AMI workflow: https://github.com/wazuh/wazuh-virtual-machines/actions/runs/11726012242/job/32663653908
- OVA workflow: https://github.com/wazuh/wazuh-virtual-machines/actions/runs/11726059491/job/32663809948

## Related issue

- #113 