### PR TITLE
Change inputs parameters in AMI and OVA workflows

### DIFF
--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -28,6 +28,11 @@ on:
         description: "Is stage?"
         type: boolean
         default: false
+      ova_revision:
+        type: string
+        description: 'Revision of the OVA file. Use "0" for development builds'
+        required: true
+        default: '0'
       checksum:
         type: boolean
         description: |
@@ -92,7 +97,7 @@ jobs:
           WAZUH_VERSION=$(cat VERSION)
           COMMIT_SHA=$(git rev-parse --short ${{ github.sha }})
           echo "WAZUH_VERSION=$WAZUH_VERSION" >> $GITHUB_ENV
-          FILENAME="wazuh-${WAZUH_VERSION}"
+          FILENAME="wazuh-${WAZUH_VERSION}-${{ inputs.OVA_REVISION }}"
 
           if [ ${{ inputs.is_stage }} == false ]; then
             FILENAME="${FILENAME}-${COMMIT_SHA}"

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -97,7 +97,7 @@ jobs:
           WAZUH_VERSION=$(cat VERSION)
           COMMIT_SHA=$(git rev-parse --short ${{ github.sha }})
           echo "WAZUH_VERSION=$WAZUH_VERSION" >> $GITHUB_ENV
-          FILENAME="wazuh-${WAZUH_VERSION}-${{ inputs.OVA_REVISION }}"
+          FILENAME="wazuh-${WAZUH_VERSION}-${{ inputs.ova_revision }}"
 
           if [ ${{ inputs.is_stage }} == false ]; then
             FILENAME="${FILENAME}-${COMMIT_SHA}"

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -20,7 +20,7 @@ on:
         description: 'Branch or tag of the wazuh-installation-assistant repository'
         required: true
         default: '4.10.0'
-      verbosity:
+      debug:
         description: 'Verbosity level on playbooks execution'
         required: true
         default: '-v'
@@ -122,7 +122,7 @@ jobs:
 
       - name: Run Ansible playbook to install Wazuh components
         run: |
-          ansible-playbook -i ${{ env.ALLOCATOR_PATH }}/inventory_ansible.ini ${{ env.PLAYBOOKS_PATH }}/build_ami_packages.yaml --extra-vars "installation_assistant_reference=${{ inputs.wazuh_installation_assistant_reference }}" ${{ inputs.verbosity }}
+          ansible-playbook -i ${{ env.ALLOCATOR_PATH }}/inventory_ansible.ini ${{ env.PLAYBOOKS_PATH }}/build_ami_packages.yaml --extra-vars "installation_assistant_reference=${{ inputs.wazuh_installation_assistant_reference }}" ${{ inputs.debug }}
 
       - name: Stop instance
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Change inputs parameters in AMI and OVA workflows ([#118](https://github.com/wazuh/wazuh-virtual-machines/pull/118))
 - Change ami and ova workflows input upper_case to lower_case ([#114](https://github.com/wazuh/wazuh-virtual-machines/pull/114))
 - Changed the SSH port of the AMI to 22 ([#83](https://github.com/wazuh/wazuh-virtual-machines/pull/83))
 - Migrated certificates and passwords changes for AMI. ([#73](https://github.com/wazuh/wazuh-virtual-machines/pull/73))


### PR DESCRIPTION
# Description

The aim of this PR is to change some input field names in the AMI and OVA workflows.

1. Change `verbosity` to debug in AMI workflow.
2. Add `ova_revision` input in OVA workflows for future uses.

## Related  issue

- #113 