### PR TITLE
Change runners in GHA workflows to Ubuntu 22.04

### DIFF
--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -82,7 +82,7 @@ permissions:
 
 jobs:
   build_and_run:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Install Python and create virtual environment
         run: |

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -58,7 +58,7 @@ permissions:
 
 jobs:
   Build_AMI:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: View parameters
         run: echo "${{ toJson(inputs) }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- None
+- Change runners in GHA workflows to Ubuntu 22.04. ([#132](https://github.com/wazuh/wazuh-virtual-machines/pull/132))
 
 ### Fixed
 


### PR DESCRIPTION
## Related
- https://github.com/wazuh/wazuh-virtual-machines/issues/129

# Description

The aim of this PR is to change the Linux image used in the Github Actions runners that we use from `ubuntu-latest` to `ubuntu-22.04`.

## Tests

AMI workflow [here](https://github.com/wazuh/wazuh-virtual-machines/actions/runs/12394791707/job/34599038515).

OVA workflow [here](https://github.com/wazuh/wazuh-virtual-machines/actions/runs/12393736026/job/34595623690).