### PR TITLE
Fixed Vagrant synced folder error in OVA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed Vagrant synced folder error in OVA. ([#183](https://github.com/wazuh/wazuh-virtual-machines/pull/183))
 - Fix the ova workflow for stages support and AWS instance deletion. ([#175](https://github.com/wazuh/wazuh-virtual-machines/pull/176))
 - Fixed the OVA workflow to add support in stages. ([#173](https://github.com/wazuh/wazuh-virtual-machines/pull/173))
 

--- a/ova/workflow_assets/Vagrantfile
+++ b/ova/workflow_assets/Vagrantfile
@@ -7,7 +7,7 @@
 # you're doing.
 Vagrant.configure("2") do |config|
   config.vm.box = "al2023"
-  # config.vm.synced_folder ".", "/vagrant/"
+  config.vm.synced_folder ".", "/vagrant/", disabled: true
   config.ssh.username = "wazuh-user"
   config.ssh.password = "wazuh"
 

--- a/ova/workflow_assets/Vagrantfile
+++ b/ova/workflow_assets/Vagrantfile
@@ -7,7 +7,7 @@
 # you're doing.
 Vagrant.configure("2") do |config|
   config.vm.box = "al2023"
-  config.vm.synced_folder ".", "/vagrant/"
+  # config.vm.synced_folder ".", "/vagrant/"
   config.ssh.username = "wazuh-user"
   config.ssh.password = "wazuh"
 


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-virtual-machines/issues/180

# Description

The aim of this PR is to delete the Vagrant synced folder message when the OVA boots up.

## Test

A tests has been done in this workflow run: https://github.com/wazuh/wazuh-virtual-machines/actions/runs/13057210395/job/36431148901

Last output before the login screen:

![imagen](https://github.com/user-attachments/assets/ae2e8b79-4b6b-492c-ac3d-52c5be611a3a)
