### PR TITLE
Changed ssh config file to allow ssh while FIPS is activated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Changed ssh config file to allow ssh while FIPS is activated. ([#184](https://github.com/wazuh/wazuh-virtual-machines/pull/184))
 - Fix the ova workflow for stages support and AWS instance deletion. ([#175](https://github.com/wazuh/wazuh-virtual-machines/pull/176))
 - Fixed the OVA workflow to add support in stages. ([#173](https://github.com/wazuh/wazuh-virtual-machines/pull/173))
 


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-virtual-machines/issues/178

# Description

The aim of this PR is to fix the connection via ssh to the OVA. This issue has appeared because FIPS is more restrictive in Amazon Linux 2023 than it was in Amazon Linux 2 and now it does support even less encryption algorithms.

## Tests

A test has been done in this workflow run: https://github.com/wazuh/wazuh-virtual-machines/actions/runs/13056367811/job/36428317531

OVA IP:

![imagen](https://github.com/user-attachments/assets/90f8c638-cedf-418b-babe-5862c257745f)

SSH connection:

![imagen](https://github.com/user-attachments/assets/64a785e6-2fb3-4ad5-b615-63eaf67b530d)
