### PR TITLE
Fixed Wazuh ASCII art logo display in OVA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed Wazuh ASCII art logo display in OVA. ([#192](https://github.com/wazuh/wazuh-virtual-machines/pull/192))
 - Fixed video in grub configuration for the OVA. ([#190](https://github.com/wazuh/wazuh-virtual-machines/pull/190))
 - Changed ssh config file to allow ssh while FIPS is activated. ([#184](https://github.com/wazuh/wazuh-virtual-machines/pull/184))
 - Fixed Vagrant synced folder error in OVA. ([#183](https://github.com/wazuh/wazuh-virtual-machines/pull/183))

--- a/ova/assets/custom/messages.sh
+++ b/ova/assets/custom/messages.sh
@@ -18,10 +18,8 @@ Login credentials:
 EOF
 
 # User Welcome message
-cat > /etc/update-motd.d/30-banner <<EOF
-
-#!/bin/sh
-cat << EOF
+rm -f /usr/lib/motd.d/30-banner
+cat > /usr/lib/motd.d/40-wazuh-banner <<EOF
 wwwwww.           wwwwwww.          wwwwwww.
 wwwwwww.          wwwwwww.          wwwwwww.
  wwwwww.         wwwwwwwww.        wwwwwww.
@@ -45,6 +43,4 @@ wwwwwww.          wwwwwww.          wwwwwww.
 
          WAZUH Open Source Security Platform
                   https://wazuh.com
-
-
 EOF

--- a/ova/assets/custom/messages.sh
+++ b/ova/assets/custom/messages.sh
@@ -44,3 +44,6 @@ wwwwwww.          wwwwwww.          wwwwwww.
          WAZUH Open Source Security Platform
                   https://wazuh.com
 EOF
+
+# Show the Wazuh banner once in SSH
+echo -e "\nif [[ \"\$(tty)\" == /dev/tty* ]]; then\n    cat /usr/lib/motd.d/40-wazuh-banner\nfi" | sudo tee -a /etc/profile


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-virtual-machines/issues/188

# Description

The aim of this PR is to fix the display of Wazuh logo in ASCII art when the user logs in the OVA.

## Tests

- A build test is done here: https://github.com/wazuh/wazuh-virtual-machines/actions/runs/13158515592/job/36721120136

The logo when you login within the VirtualBox windows shows this way:

![Captura desde 2025-02-05 16-41-17](https://github.com/user-attachments/assets/d67272f1-17dc-4611-bd2e-2accc0154ca9)

The logo when you login via ssh shows this way:

![Captura desde 2025-02-05 16-42-02](https://github.com/user-attachments/assets/f391cfcd-a9ea-4391-af23-8df789ef5705)

