### PR TITLE
Fixed Wazuh Dashboard issues when the AMI boots up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed Wazuh Dashboard issues when the AMI boots up. ([#205](https://github.com/wazuh/wazuh-virtual-machines/pull/205))
 - Fix Wazuh dashboard certificate verification failure ([#198](https://github.com/wazuh/wazuh-virtual-machines/pull/198))
 - Fixed Wazuh ASCII art logo display in OVA. ([#192](https://github.com/wazuh/wazuh-virtual-machines/pull/192))
 - Fixed video in grub configuration for the OVA. ([#190](https://github.com/wazuh/wazuh-virtual-machines/pull/190))

--- a/ami/playbooks/build_ami_packages.yaml
+++ b/ami/playbooks/build_ami_packages.yaml
@@ -296,6 +296,12 @@
         enabled: yes
         daemon_reload: yes
 
+    - name: Disable Wazuh Dashboard service
+      systemd:
+        name: wazuh-dashboard
+        enabled: no
+        state: stopped
+
     - name: Change SSH port to 22
       lineinfile:
         path: /etc/ssh/sshd_config

--- a/ami/wazuh-ami-customizer.service
+++ b/ami/wazuh-ami-customizer.service
@@ -10,18 +10,10 @@
 [Unit]
 Description=Creates custom certificates and passwords for Wazuh AMI
 Wants=wazuh-ami-customizer.timer
-Before=wazuh-indexer.service
-Before=wazuh-manager.service
-Before=filebeat.service
-Before=wazuh-dashboard.service
 
 [Service]
 Type=oneshot
 ExecStart=/etc/.wazuh-ami-customizer.sh
-ExecStartPost=/bin/systemctl restart wazuh-indexer.service
-ExecStartPost=/bin/systemctl restart wazuh-manager.service
-ExecStartPost=/bin/systemctl restart filebeat.service
-ExecStartPost=/bin/systemctl restart wazuh-dashboard.service
 
 [Install]
 WantedBy=multi-user.target

--- a/ami/wazuh-ami-customizer.service
+++ b/ami/wazuh-ami-customizer.service
@@ -10,6 +10,10 @@
 [Unit]
 Description=Creates custom certificates and passwords for Wazuh AMI
 Wants=wazuh-ami-customizer.timer
+Before=wazuh-indexer.service
+Before=wazuh-manager.service
+Before=filebeat.service
+Before=wazuh-dashboard.service
 
 [Service]
 Type=oneshot

--- a/ami/wazuh-ami-customizer.service
+++ b/ami/wazuh-ami-customizer.service
@@ -18,6 +18,10 @@ Before=wazuh-dashboard.service
 [Service]
 Type=oneshot
 ExecStart=/etc/.wazuh-ami-customizer.sh
+ExecStartPost=/bin/systemctl restart wazuh-indexer.service
+ExecStartPost=/bin/systemctl restart wazuh-manager.service
+ExecStartPost=/bin/systemctl restart filebeat.service
+ExecStartPost=/bin/systemctl restart wazuh-dashboard.service
 
 [Install]
 WantedBy=multi-user.target

--- a/ami/wazuh-ami-customizer.sh
+++ b/ami/wazuh-ami-customizer.sh
@@ -215,6 +215,7 @@ until $(curl -XGET https://localhost:9200/ -uadmin:${new_password} -k --max-time
 done
 
 eval "systemctl start wazuh-dashboard ${debug}"
+eval "systemctl enable wazuh-dashboard ${debug}"
 
 restart_ssh_service
 

--- a/ami/wazuh-ami-customizer.sh
+++ b/ami/wazuh-ami-customizer.sh
@@ -175,17 +175,6 @@ logger "Starting Wazuh AMI Customizer"
 logger "Stopping SSH service to avoid connections during the configuration"
 eval "systemctl stop sshd.service"
 
-{
-  echo "Wazuh Services Status"
-  echo ""
-
-  for service in wazuh-indexer wazuh-manager wazuh-dashboard filebeat; do
-    echo "=== Status of ${service} - $(date '+%Y-%m-%d %H:%M:%S') ==="
-    eval "systemctl status ${service} ${debug}"
-    echo ""
-  done
-} >> "/home/wazuh-user/wazuh-services-status.log"
-
 logger "Waiting for Wazuh indexer to be ready"
 until $(curl -XGET https://localhost:9200/ -uadmin:admin -k --max-time 120 --silent --output /dev/null); do
   logger -w "Wazuh indexer is not ready yet, waiting 10 seconds"
@@ -221,13 +210,3 @@ systemctl_execution "enable" "wazuh-dashboard" "${debug}"
 restart_ssh_service
 
 clean_configuration
-
-{
-  echo ""
-  echo "Wazuh Services Status after clean"
-  for service in wazuh-indexer wazuh-manager wazuh-dashboard filebeat; do
-    echo "=== Status of ${service} - $(date '+%Y-%m-%d %H:%M:%S') ==="
-    eval "systemctl status ${service} ${debug}"
-    echo ""
-  done
-} >> "/home/wazuh-user/wazuh-services-status.log"

--- a/ami/wazuh-ami-customizer.sh
+++ b/ami/wazuh-ami-customizer.sh
@@ -47,6 +47,7 @@ function configure_indexer(){
   eval "systemctl stop wazuh-dashboard ${debug}"
   eval "systemctl stop wazuh-manager ${debug}"
   eval "systemctl stop wazuh-indexer ${debug}"
+  eval "sleep 15"
   logger "Configuring Wazuh Indexer"
   eval "rm -f /etc/wazuh-indexer/certs/* ${debug}"
   eval "cp /etc/wazuh-certificates/wazuh-indexer.pem /etc/wazuh-indexer/certs/wazuh-indexer.pem ${debug}"
@@ -170,6 +171,17 @@ logger "Starting Wazuh AMI Customizer"
 logger "Stopping SSH service to avoid connections during the configuration"
 eval "systemctl stop sshd.service"
 
+{
+  echo "Wazuh Services Status"
+  echo ""
+
+  for service in wazuh-indexer wazuh-manager wazuh-dashboard filebeat; do
+    echo "=== Status of ${service} ==="
+    eval "systemctl status ${service} ${debug}"
+    echo ""
+  done
+} > "/home/wazuh-user/wazuh-services-status.log"
+
 logger "Waiting for Wazuh indexer to be ready"
 until $(curl -XGET https://localhost:9200/ -uadmin:admin -k --max-time 120 --silent --output /dev/null); do
   logger -w "Wazuh indexer is not ready yet, waiting 10 seconds"
@@ -190,6 +202,8 @@ configure_dashboard
 verify_dashboard
 
 eval "systemctl stop wazuh-dashboard ${debug}"
+
+eval "sleep 15"
 
 change_passwords
 

--- a/ami/wazuh-ami-customizer.sh
+++ b/ami/wazuh-ami-customizer.sh
@@ -47,7 +47,7 @@ function configure_indexer(){
   eval "systemctl stop wazuh-dashboard ${debug}"
   eval "systemctl stop wazuh-manager ${debug}"
   eval "systemctl stop wazuh-indexer ${debug}"
-  eval "sleep 15"
+  eval "sleep 5"
   logger "Configuring Wazuh Indexer"
   eval "rm -f /etc/wazuh-indexer/certs/* ${debug}"
   eval "cp /etc/wazuh-certificates/wazuh-indexer.pem /etc/wazuh-indexer/certs/wazuh-indexer.pem ${debug}"
@@ -58,9 +58,9 @@ function configure_indexer(){
   eval "chmod 500 /etc/wazuh-indexer/certs ${debug}"
   eval "chmod 400 /etc/wazuh-indexer/certs/* ${debug}"
   eval "chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/certs ${debug}"
-  echo "Before starting the wazuh-indexer inside configure_indexer function" >> /home/wazuh-user/wazuh-services-status.log
+  echo "Before starting the wazuh-indexer inside configure_indexer function - $(date '+%Y-%m-%d %H:%M:%S')" >> /home/wazuh-user/wazuh-services-status.log
   eval "systemctl start wazuh-indexer ${debug}"
-  echo "After starting the wazuh-indexer inside configure_indexer function" >> /home/wazuh-user/wazuh-services-status.log
+  echo "After starting the wazuh-indexer inside configure_indexer function - $(date '+%Y-%m-%d %H:%M:%S')" >> /home/wazuh-user/wazuh-services-status.log
   eval "/usr/share/wazuh-indexer/bin/indexer-security-init.sh ${debug}"
 }
 
@@ -178,7 +178,7 @@ eval "systemctl stop sshd.service"
   echo ""
 
   for service in wazuh-indexer wazuh-manager wazuh-dashboard filebeat; do
-    echo "=== Status of ${service} ==="
+    echo "=== Status of ${service} - $(date '+%Y-%m-%d %H:%M:%S') ==="
     eval "systemctl status ${service} ${debug}"
     echo ""
   done
@@ -205,7 +205,7 @@ verify_dashboard
 
 eval "systemctl stop wazuh-dashboard ${debug}"
 
-eval "sleep 15"
+eval "sleep 5"
 
 change_passwords
 
@@ -225,7 +225,7 @@ clean_configuration
   echo ""
   echo "Wazuh Services Status after clean"
   for service in wazuh-indexer wazuh-manager wazuh-dashboard filebeat; do
-    echo "=== Status of ${service} ==="
+    echo "=== Status of ${service} - $(date '+%Y-%m-%d %H:%M:%S') ==="
     eval "systemctl status ${service} ${debug}"
     echo ""
   done

--- a/ami/wazuh-ami-customizer.sh
+++ b/ami/wazuh-ami-customizer.sh
@@ -151,9 +151,11 @@ function clean_configuration(){
 
 function change_passwords(){
   logger "Changing passwords"
+  eval "systemctl stop wazuh-dashboard ${debug}"
   new_password=$(ec2-metadata | grep "instance-id" | cut -d":" -f2 | tr -d " "| awk '{print toupper(substr($0,1,1)) substr($0,2)}')
   eval "sed -i 's/password:.*/password: ${new_password}/g' /etc/.wazuh-install-files/wazuh-passwords.txt ${debug}"
   eval "bash /etc/.wazuh-passwords-tool.sh -a -A -au wazuh -ap wazuh -f /etc/.wazuh-install-files/wazuh-passwords.txt >> /dev/null"
+  eval "systemctl start wazuh-dashboard ${debug}"
 }
 
 function restart_ssh_service(){
@@ -189,16 +191,12 @@ configure_manager
 configure_dashboard
 verify_dashboard
 
-eval "systemctl stop wazuh-dashboard ${debug}"
-
 change_passwords
 
 logger "Waiting for Wazuh indexer to be ready with new password"
 until $(curl -XGET https://localhost:9200/ -uadmin:${new_password} -k --max-time 120 --silent --output /dev/null); do
   sleep 10
 done
-
-eval "systemctl start wazuh-dashboard ${debug}"
 
 restart_ssh_service
 

--- a/ami/wazuh-ami-customizer.sh
+++ b/ami/wazuh-ami-customizer.sh
@@ -151,10 +151,11 @@ function clean_configuration(){
 
 function change_passwords(){
   logger "Changing passwords"
+  eval "systemctl stop wazuh-dashboard ${debug}"
   new_password=$(ec2-metadata | grep "instance-id" | cut -d":" -f2 | tr -d " "| awk '{print toupper(substr($0,1,1)) substr($0,2)}')
   eval "sed -i 's/password:.*/password: ${new_password}/g' /etc/.wazuh-install-files/wazuh-passwords.txt ${debug}"
   eval "bash /etc/.wazuh-passwords-tool.sh -a -A -au wazuh -ap wazuh -f /etc/.wazuh-install-files/wazuh-passwords.txt >> /dev/null"
-  eval "systemctl restart wazuh-dashboard ${debug}"
+  eval "systemctl start wazuh-dashboard ${debug}"
 }
 
 function restart_ssh_service(){

--- a/ami/wazuh-ami-customizer.sh
+++ b/ami/wazuh-ami-customizer.sh
@@ -58,7 +58,9 @@ function configure_indexer(){
   eval "chmod 500 /etc/wazuh-indexer/certs ${debug}"
   eval "chmod 400 /etc/wazuh-indexer/certs/* ${debug}"
   eval "chown -R wazuh-indexer:wazuh-indexer /etc/wazuh-indexer/certs ${debug}"
+  echo "Before starting the wazuh-indexer inside configure_indexer function" >> /home/wazuh-user/wazuh-services-status.log
   eval "systemctl start wazuh-indexer ${debug}"
+  echo "After starting the wazuh-indexer inside configure_indexer function" >> /home/wazuh-user/wazuh-services-status.log
   eval "/usr/share/wazuh-indexer/bin/indexer-security-init.sh ${debug}"
 }
 
@@ -180,7 +182,7 @@ eval "systemctl stop sshd.service"
     eval "systemctl status ${service} ${debug}"
     echo ""
   done
-} > "/home/wazuh-user/wazuh-services-status.log"
+} >> "/home/wazuh-user/wazuh-services-status.log"
 
 logger "Waiting for Wazuh indexer to be ready"
 until $(curl -XGET https://localhost:9200/ -uadmin:admin -k --max-time 120 --silent --output /dev/null); do
@@ -226,4 +228,4 @@ clean_configuration
     eval "systemctl status ${service} ${debug}"
     echo ""
   done
-} > "/home/wazuh-user/wazuh-services-status.log"
+} >> "/home/wazuh-user/wazuh-services-status.log"

--- a/ami/wazuh-ami-customizer.sh
+++ b/ami/wazuh-ami-customizer.sh
@@ -217,3 +217,13 @@ eval "systemctl start wazuh-dashboard ${debug}"
 restart_ssh_service
 
 clean_configuration
+
+{
+  echo ""
+  echo "Wazuh Services Status after clean"
+  for service in wazuh-indexer wazuh-manager wazuh-dashboard filebeat; do
+    echo "=== Status of ${service} ==="
+    eval "systemctl status ${service} ${debug}"
+    echo ""
+  done
+} > "/home/wazuh-user/wazuh-services-status.log"


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-virtual-machines/issues/200

# Description

The aim of this PR is to fix the reported log errors in the related issue. These errors came up because the Wazuh Dashboard is booted up by the systemd of the OS before the `wazuh-ami-customizer.sh` script is run. So this causes the Wazuh Dashboard to be on while the Wazuh Indexer, Wazuh Server and Filebeat are off and this causes that error logs.

The solution we have come up with is to disable the Wazuh Dashboard service at the end of the Wazuh AMI build process. Then, in the execution of the `wazuh-ami-customizer.sh` script, the configurations are done and the Wazuh Dashboard is booted up and enabled. This change makes the log errors dissappear and we can boot up the Wazuh central components one by one in the order we want.

## Tests

### AMI building

The AMI was built here: https://github.com/wazuh/wazuh-virtual-machines/actions/runs/13287475760

### Wazuh Dashboard error logs after booting up the AMI instance

```shellsession
[wazuh-user@ip-172-31-47-237 ~]$ journalctl -r -u wazuh-dashboard | grep -i -E "error|critical|fatal"
Feb 12 15:30:00 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:30:00Z","tags":["error","opensearch","data"],"pid":9663,"message":"[resource_already_exists_exception]: index [wazuh-statistics-2025.7w/JRv9R412QAyfrAo_-Y0vlw] already exists"}
```

### Wazuh Dashboard landing page

![Captura desde 2025-02-12 16-50-40](https://github.com/user-attachments/assets/06458166-0cb4-4eda-9c7d-fff8b68dec1d)

### Logging before and after the `wazuh-ami-customizer.sh` script

In a development AMI I included a logger to check that the services are down before the script execution and they are up after the script finishes. I also added the timestamps to know how much time takes the execution of the script and we acn see that it takes about five minutes as indicated in the Wazuh AMI AWS Marketplace information.

> [!IMPORTANT]  
> This log only exists in my development stage. In production, this does not exists.

Logs following:

```shellsession
Wazuh Services Status

=== Status of wazuh-indexer - 2025-02-12 15:25:00 ===
○ wazuh-indexer.service - wazuh-indexer
     Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; enabled; preset: disabled)
     Active: inactive (dead)
       Docs: https://documentation.wazuh.com

=== Status of wazuh-manager - 2025-02-12 15:25:00 ===
○ wazuh-manager.service - Wazuh manager
     Loaded: loaded (/usr/lib/systemd/system/wazuh-manager.service; enabled; preset: disabled)
     Active: inactive (dead)

=== Status of wazuh-dashboard - 2025-02-12 15:25:00 ===
○ wazuh-dashboard.service - wazuh-dashboard
     Loaded: loaded (/etc/systemd/system/wazuh-dashboard.service; disabled; preset: disabled)
     Active: inactive (dead)

=== Status of filebeat - 2025-02-12 15:25:01 ===
○ filebeat.service - Filebeat sends log files to Logstash or directly to Elasticsearch.
     Loaded: loaded (/usr/lib/systemd/system/filebeat.service; enabled; preset: disabled)
     Active: inactive (dead)
       Docs: https://www.elastic.co/products/beats/filebeat


Wazuh Services Status after clean
=== Status of wazuh-indexer - 2025-02-12 15:29:48 ===
● wazuh-indexer.service - wazuh-indexer
     Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; enabled; preset: disabled)
     Active: active (running) since Wed 2025-02-12 15:27:32 UTC; 2min 15s ago
       Docs: https://documentation.wazuh.com
   Main PID: 4881 (java)
      Tasks: 89 (limit: 9343)
     Memory: 4.2G
        CPU: 48.883s
     CGroup: /system.slice/wazuh-indexer.service
             └─4881 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTraceInFastThrow -XX:+ShowCodeDetailsInExceptionMessages -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0 -Dio.netty.allocator.numDirectArenas=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true -Djava.security.manager=allow -Djava.locale.providers=SPI,COMPAT -Xms3905m -Xmx3905m -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -Djava.io.tmpdir=/var/lib/wazuh-indexer/tmp -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/var/lib/wazuh-indexer -XX:ErrorFile=/var/log/wazuh-indexer/hs_err_pid%p.log "-Xlog:gc*,gc+age=trace,safepoint:file=/var/log/wazuh-indexer/gc.log:utctime,pid,tags:filecount=32,filesize=64m" -Djava.security.manager=allow -Djava.util.concurrent.ForkJoinPool.common.threadFactory=org.opensearch.secure_sm.SecuredForkJoinWorkerThreadFactory -Dclk.tck=100 -Djdk.attach.allowAttachSelf=true -Djava.security.policy=file:///etc/wazuh-indexer/opensearch-performance-analyzer/opensearch_security.policy --add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED -XX:MaxDirectMemorySize=2047868928 -Dopensearch.path.home=/usr/share/wazuh-indexer -Dopensearch.path.conf=/etc/wazuh-indexer -Dopensearch.distribution.type=rpm -Dopensearch.bundled_jdk=true -cp "/usr/share/wazuh-indexer/lib/*" org.opensearch.bootstrap.OpenSearch -p /run/wazuh-indexer/wazuh-indexer.pid --quiet

Feb 12 15:27:21 ip-172-31-47-237.ec2.internal systemd-entrypoint[4881]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.OpenSearch (file:/usr/share/wazuh-indexer/lib/opensearch-2.16.0.jar)
Feb 12 15:27:21 ip-172-31-47-237.ec2.internal systemd-entrypoint[4881]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.OpenSearch
Feb 12 15:27:21 ip-172-31-47-237.ec2.internal systemd-entrypoint[4881]: WARNING: System::setSecurityManager will be removed in a future release
Feb 12 15:27:22 ip-172-31-47-237.ec2.internal systemd-entrypoint[4881]: Feb 12, 2025 3:27:22 PM sun.util.locale.provider.LocaleProviderAdapter <clinit>
Feb 12 15:27:22 ip-172-31-47-237.ec2.internal systemd-entrypoint[4881]: WARNING: COMPAT locale provider will be removed in a future release
Feb 12 15:27:22 ip-172-31-47-237.ec2.internal systemd-entrypoint[4881]: WARNING: A terminally deprecated method in java.lang.System has been called
Feb 12 15:27:22 ip-172-31-47-237.ec2.internal systemd-entrypoint[4881]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.Security (file:/usr/share/wazuh-indexer/lib/opensearch-2.16.0.jar)
Feb 12 15:27:22 ip-172-31-47-237.ec2.internal systemd-entrypoint[4881]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.Security
Feb 12 15:27:22 ip-172-31-47-237.ec2.internal systemd-entrypoint[4881]: WARNING: System::setSecurityManager will be removed in a future release
Feb 12 15:27:32 ip-172-31-47-237.ec2.internal systemd[1]: Started wazuh-indexer.service - wazuh-indexer.

=== Status of wazuh-manager - 2025-02-12 15:29:48 ===
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/usr/lib/systemd/system/wazuh-manager.service; enabled; preset: disabled)
     Active: active (running) since Wed 2025-02-12 15:29:37 UTC; 11s ago
      Tasks: 173 (limit: 9343)
     Memory: 579.5M
        CPU: 21.570s
     CGroup: /system.slice/wazuh-manager.service
             ├─8503 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─8504 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─8507 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─8510 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─8552 /var/ossec/bin/wazuh-authd
             ├─8566 /var/ossec/bin/wazuh-db
             ├─8592 /var/ossec/bin/wazuh-execd
             ├─8604 /var/ossec/bin/wazuh-analysisd
             ├─8614 /var/ossec/bin/wazuh-syscheckd
             ├─8681 /var/ossec/bin/wazuh-remoted
             ├─8719 /var/ossec/bin/wazuh-logcollector
             ├─8775 /var/ossec/bin/wazuh-monitord
             └─8785 /var/ossec/bin/wazuh-modulesd

Feb 12 15:29:30 ip-172-31-47-237.ec2.internal env[8441]: Started wazuh-analysisd...
Feb 12 15:29:31 ip-172-31-47-237.ec2.internal env[8441]: Started wazuh-syscheckd...
Feb 12 15:29:33 ip-172-31-47-237.ec2.internal env[8441]: Started wazuh-remoted...
Feb 12 15:29:34 ip-172-31-47-237.ec2.internal env[8441]: Started wazuh-logcollector...
Feb 12 15:29:34 ip-172-31-47-237.ec2.internal env[8441]: Started wazuh-monitord...
Feb 12 15:29:34 ip-172-31-47-237.ec2.internal env[8783]: 2025/02/12 15:29:34 wazuh-modulesd:router: INFO: Loaded router module.
Feb 12 15:29:34 ip-172-31-47-237.ec2.internal env[8783]: 2025/02/12 15:29:34 wazuh-modulesd:content_manager: INFO: Loaded content_manager module.
Feb 12 15:29:35 ip-172-31-47-237.ec2.internal env[8441]: Started wazuh-modulesd...
Feb 12 15:29:37 ip-172-31-47-237.ec2.internal env[8441]: Completed.
Feb 12 15:29:37 ip-172-31-47-237.ec2.internal systemd[1]: Started wazuh-manager.service - Wazuh manager.

=== Status of wazuh-dashboard - 2025-02-12 15:29:48 ===
● wazuh-dashboard.service - wazuh-dashboard
     Loaded: loaded (/etc/systemd/system/wazuh-dashboard.service; enabled; preset: disabled)
     Active: active (running) since Wed 2025-02-12 15:29:38 UTC; 9s ago
   Main PID: 9663 (node)
      Tasks: 11 (limit: 9343)
     Memory: 283.7M
        CPU: 7.059s
     CGroup: /system.slice/wazuh-dashboard.service
             └─9663 /usr/share/wazuh-dashboard/node/bin/node --no-warnings --max-http-header-size=65536 --unhandled-rejections=warn /usr/share/wazuh-dashboard/src/cli/dist

Feb 12 15:29:44 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:29:44Z","tags":["warning","cross-compatibility-service"],"pid":9663,"message":"Starting cross compatibility service"}
Feb 12 15:29:44 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:29:44Z","tags":["info","plugins-system"],"pid":9663,"message":"Starting [50] plugins: [usageCollection,opensearchDashboardsUsageCollection,opensearchDashboardsLegacy,mapsLegacy,share,opensearchUiShared,legacyExport,embeddable,expressions,data,savedObjects,queryEnhancements,home,apmOss,reportsDashboards,dashboard,visualizations,visTypeVega,visTypeTimeline,visTypeTable,visTypeMarkdown,visBuilder,visAugmenter,tileMap,regionMap,inputControlVis,ganttChartDashboards,visualize,management,indexPatternManagement,dataSourceManagement,indexManagementDashboards,customImportMapDashboards,alertingDashboards,notificationsDashboards,console,advancedSettings,dataExplorer,charts,visTypeVislib,visTypeTimeseries,visTypeTagcloud,visTypeMetric,discover,savedObjectsManagement,securityDashboards,wazuhCore,wazuhCheckUpdates,wazuh,bfetch]"}
Feb 12 15:29:44 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:29:44Z","tags":["info","plugins","wazuh","initialize"],"pid":9663,"message":"dashboard index: .kibana"}
Feb 12 15:29:44 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:29:44Z","tags":["info","plugins","wazuh","initialize"],"pid":9663,"message":"App revision: 02"}
Feb 12 15:29:44 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:29:44Z","tags":["info","plugins","wazuh","initialize"],"pid":9663,"message":"Total RAM: 7812MB"}
Feb 12 15:29:44 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:29:44Z","tags":["info","plugins","wazuh","monitoring"],"pid":9663,"message":"Updated the wazuh-agent template"}
Feb 12 15:29:44 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:29:44Z","tags":["listening","info"],"pid":9663,"message":"Server running at https://0.0.0.0:443"}
Feb 12 15:29:45 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:29:45Z","tags":["info","http","server","OpenSearchDashboards"],"pid":9663,"message":"http server running at https://0.0.0.0:443"}
Feb 12 15:29:45 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:29:45Z","tags":["info","plugins","wazuh","cron-scheduler"],"pid":9663,"message":"Updated the wazuh-statistics template"}
Feb 12 15:29:45 ip-172-31-47-237.ec2.internal opensearch-dashboards[9663]: {"type":"log","@timestamp":"2025-02-12T15:29:45Z","tags":["info","plugins","wazuh","monitoring"],"pid":9663,"message":"Settings added to wazuh-monitoring-2025.7w index"}

=== Status of filebeat - 2025-02-12 15:29:48 ===
● filebeat.service - Filebeat sends log files to Logstash or directly to Elasticsearch.
     Loaded: loaded (/usr/lib/systemd/system/filebeat.service; enabled; preset: disabled)
     Active: active (running) since Wed 2025-02-12 15:29:21 UTC; 26s ago
       Docs: https://www.elastic.co/products/beats/filebeat
   Main PID: 8199 (filebeat)
      Tasks: 9 (limit: 9343)
     Memory: 9.6M
        CPU: 68ms
     CGroup: /system.slice/filebeat.service
             └─8199 /usr/share/filebeat/bin/filebeat --environment systemd -c /etc/filebeat/filebeat.yml --path.home /usr/share/filebeat --path.config /etc/filebeat --path.data /var/lib/filebeat --path.logs /var/log/filebeat

Feb 12 15:29:21 ip-172-31-47-237.ec2.internal systemd[1]: Started filebeat.service - Filebeat sends log files to Logstash or directly to Elasticsearch..
```