### PR TITLE
Fix Wazuh dashboard errors in OVA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix Wazuh dashboard errors in OVA. ([#209](https://github.com/wazuh/wazuh-virtual-machines/pull/209))
 - Fixed local build for OVA. ([#208](https://github.com/wazuh/wazuh-virtual-machines/pull/208))
 - Fixed Wazuh Dashboard issues when the AMI boots up. ([#205](https://github.com/wazuh/wazuh-virtual-machines/pull/205))
 - Fix Wazuh dashboard certificate verification failure ([#198](https://github.com/wazuh/wazuh-virtual-machines/pull/198))

--- a/ova/assets/custom/wazuh-starter/wazuh-starter.service
+++ b/ova/assets/custom/wazuh-starter/wazuh-starter.service
@@ -1,0 +1,19 @@
+# Wazuh AMI Customizer Service - Used to customize the Wazuh AMI with custom certificates and passwords
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+#
+
+[Unit]
+Description=Starts Wazuh services in order
+Wants=wazuh-starter.timer
+
+[Service]
+Type=oneshot
+ExecStart=/etc/.wazuh-starter.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/ova/assets/custom/wazuh-starter/wazuh-starter.sh
+++ b/ova/assets/custom/wazuh-starter/wazuh-starter.sh
@@ -110,7 +110,7 @@ verify_filebeat
 
 starter_service wazuh-dashboard
 verify_dashboard
-systemctl enable wazuh-dashboard
 systemctl enable wazuh-manager
+systemctl enable wazuh-dashboard
 
-#clean_configuration
+clean_configuration

--- a/ova/assets/custom/wazuh-starter/wazuh-starter.sh
+++ b/ova/assets/custom/wazuh-starter/wazuh-starter.sh
@@ -111,5 +111,6 @@ verify_filebeat
 starter_service wazuh-dashboard
 verify_dashboard
 systemctl enable wazuh-dashboard
+systemctl enable wazuh-manager
 
 #clean_configuration

--- a/ova/assets/custom/wazuh-starter/wazuh-starter.sh
+++ b/ova/assets/custom/wazuh-starter/wazuh-starter.sh
@@ -112,4 +112,4 @@ starter_service wazuh-dashboard
 verify_dashboard
 systemctl enable wazuh-dashboard
 
-clean_configuration
+#clean_configuration

--- a/ova/assets/custom/wazuh-starter/wazuh-starter.sh
+++ b/ova/assets/custom/wazuh-starter/wazuh-starter.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# This script is used to configure the Wazuh environment after the installation
+
+# Variables
+logfile="/var/log/wazuh-starter.log"
+debug="| tee -a ${logfile}"
+
+###########################################
+# Utility Functions
+###########################################
+function logger(){
+  now=$(date +'%d/%m/%Y %H:%M:%S')
+  mtype="INFO:"
+  if [ -n "${1}" ]; then
+      while [ -n "${1}" ]; do
+          case ${1} in
+              "-e")
+                  mtype="ERROR:"
+                  shift 1
+                  ;;
+              "-w")
+                  mtype="WARNING:"
+                  shift 1
+                  ;;
+              *)
+                  message="${1}"
+                  shift 1
+                  ;;
+          esac
+      done
+  fi
+  printf "%s\n" "${now} ${mtype} ${message}" | tee -a "${logfile}"
+}
+
+
+###########################################
+# Configuration Functions
+###########################################
+
+function starter_service() {
+  logger "Starting $1 service"
+  systemctl start $1
+}
+
+function verify_indexer() {
+  logger "Waiting for Wazuh indexer to be ready"
+  indexer_security_admin_comm="curl -XGET https://localhost:9200/ -uadmin:admin -k --max-time 120 --silent -w \"%{http_code}\" --output /dev/null"
+  http_status=$(eval "${indexer_security_admin_comm}")
+  retries=0
+  max_retries=5
+  while [ "${http_status}" -ne 200 ]; do
+      logger -w "Wazuh indexer is not ready yet, waiting 5 seconds"
+      sleep 5
+      retries=$((retries+1))
+      if [ "${retries}" -eq "${max_retries}" ]; then
+          logger -e "Wazuh indexer is not ready yet, trying to configure it again"
+          configure_indexer
+      fi
+      http_status=$(eval "${indexer_security_admin_comm}")
+  done
+}
+
+function verify_filebeat() {
+  logger "Waiting for Filebeat to be ready"
+  if  filebeat test output | grep -q -i -w "ERROR"; then
+    logger -e "Filebeat is not ready yet, trying to configure it again"
+    eval "filebeat test output x ${debug}"
+    configure_filebeat
+  fi
+}
+
+function verify_dashboard() {
+  logger "Waiting for Wazuh dashboard to be ready"
+  dashboard_check_comm="curl -XGET https://localhost:443/status -uadmin:admin -k -w \"%{http_code}\" -s -o /dev/null"
+  http_code=$(eval "${dashboard_check_comm}")
+  retries=0
+  max_dashboard_initialize_retries=20
+  while [ "${http_code}" -ne "200" ];do
+      logger -w "Wazuh dashboard is not ready yet, waiting 15 seconds"
+      retries=$((retries+1))
+      sleep 15
+      if [ "${retries}" -eq "${max_dashboard_initialize_retries}" ]; then
+          logger -e "Wazuh dashboard is not ready yet, trying to configure it again"
+          configure_dashboard
+      fi
+      http_code=$(eval "${dashboard_check_comm}")
+  done
+}
+
+function clean_configuration(){
+  logger "Cleaning configuration files"
+  eval "rm -rf /var/log/wazuh-starter.log"
+  eval "rm -f /etc/.wazuh-starter.sh /etc/systemd/system/wazuh-starter.service /etc/systemd/system/wazuh-starter.timer"
+}
+
+
+###########################################
+# Main
+###########################################
+
+logger "Starting Wazuh services in order"
+
+
+starter_service wazuh-indexer
+verify_indexer
+
+starter_service wazuh-manager
+starter_service filebeat
+verify_filebeat
+
+starter_service wazuh-dashboard
+verify_dashboard
+systemctl enable wazuh-dashboard
+
+clean_configuration

--- a/ova/assets/custom/wazuh-starter/wazuh-starter.timer
+++ b/ova/assets/custom/wazuh-starter/wazuh-starter.timer
@@ -1,0 +1,19 @@
+# Wazuh AMI Customizer Service - Used to customize the Wazuh AMI with custom certificates and passwords
+# Copyright (C) 2015, Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+#
+
+[Unit]
+Description=Starts Wazuh services in order
+Requires=wazuh-starter.service
+
+[Timer]
+Unit=wazuh-starter.service
+OnBootSec=10s
+
+[Install]
+WantedBy=timers.target

--- a/ova/assets/steps.sh
+++ b/ova/assets/steps.sh
@@ -27,6 +27,7 @@ systemConfig() {
   chmod 755 /tmp/enable_fips.sh
   bash /tmp/enable_fips.sh
 
+  set -x
   # Update Wazuh indexer jvm heap
   mv ${CUSTOM_PATH}/automatic_set_ram.sh /etc/
   chmod 755 /etc/automatic_set_ram.sh
@@ -34,6 +35,15 @@ systemConfig() {
   systemctl daemon-reload
   systemctl enable updateIndexerHeap.service
 
+  # Add Wazuh starter service
+  mv ${CUSTOM_PATH}/wazuh-starter/wazuh-starter.service /etc/systemd/system/
+  mv ${CUSTOM_PATH}/wazuh-starter/wazuh-starter.timer /etc/systemd/system/
+  mv ${CUSTOM_PATH}/wazuh-starter/wazuh-starter.sh /etc/.wazuh-starter.sh
+  systemctl daemon-reload
+  systemctl enable wazuh-starter.timer
+  systemctl enable wazuh-starter.service
+
+  set +x
 
   # Change root password (root:wazuh)
   sed -i "s/root:.*:/root:\$1\$pNjjEA7K\$USjdNwjfh7A\.vHCf8suK41::0:99999:7:::/g" /etc/shadow

--- a/ova/assets/steps.sh
+++ b/ova/assets/steps.sh
@@ -39,6 +39,7 @@ systemConfig() {
   mv ${CUSTOM_PATH}/wazuh-starter/wazuh-starter.service /etc/systemd/system/
   mv ${CUSTOM_PATH}/wazuh-starter/wazuh-starter.timer /etc/systemd/system/
   mv ${CUSTOM_PATH}/wazuh-starter/wazuh-starter.sh /etc/.wazuh-starter.sh
+  chmod 755 /etc/.wazuh-starter.sh
   systemctl daemon-reload
   systemctl enable wazuh-starter.timer
   systemctl enable wazuh-starter.service

--- a/ova/assets/steps.sh
+++ b/ova/assets/steps.sh
@@ -27,7 +27,6 @@ systemConfig() {
   chmod 755 /tmp/enable_fips.sh
   bash /tmp/enable_fips.sh
 
-  set -x
   # Update Wazuh indexer jvm heap
   mv ${CUSTOM_PATH}/automatic_set_ram.sh /etc/
   chmod 755 /etc/automatic_set_ram.sh
@@ -43,8 +42,6 @@ systemConfig() {
   systemctl daemon-reload
   systemctl enable wazuh-starter.timer
   systemctl enable wazuh-starter.service
-
-  set +x
 
   # Change root password (root:wazuh)
   sed -i "s/root:.*:/root:\$1\$pNjjEA7K\$USjdNwjfh7A\.vHCf8suK41::0:99999:7:::/g" /etc/shadow

--- a/ova/provision.sh
+++ b/ova/provision.sh
@@ -56,7 +56,8 @@ bash /usr/share/wazuh-indexer/bin/indexer-security-init.sh -ho 127.0.0.1
 
 echo "Stopping Wazuh indexer and Wazuh dashboard"
 systemctl stop wazuh-indexer wazuh-dashboard
-systemctl enable wazuh-manager
+systemctl disable wazuh-manager
+systemctl disable wazuh-dashboard
 
 echo "Cleaning system"
 clean


### PR DESCRIPTION
Close https://github.com/wazuh/wazuh-virtual-machines/issues/202

A new script has been added that orders the start of the services to avoid connection errors by the dashboard.

## Tests

```console

cbordon@cbordon-MS-7C88:/tmp/wazuh-virtual-machines/ova$ sudo bash generate_ova.sh -a v4.11.0-beta1 -r dev
Building Wazuh OVA version 4.11.0
Cloning Wazuh installation assistant repository
Using v4.11.0-beta1 branch of wazuh-installation-assistant repository
Building Wazuh installation assistant from v4.11.0-beta1 branch
Version to build: 4.11.0 with development repository
==> default: VM not created. Moving on...
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'al2023'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: vm_wazuh
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: wazuh-user
    default: SSH auth method: private key
    default: Warning: Connection reset. Retrying...
    default: Warning: Remote connection disconnect. Retrying...
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: The guest additions on this VM do not match the installed version of
    default: VirtualBox! In most cases this is fine, but in rare cases it can
    default: prevent things such as shared folders from working properly. If you see
    default: shared folder errors, please make sure the guest additions within the
    default: virtual machine match the version of VirtualBox you have installed on
    default: your host and reload your VM.
    default: 
    default: Guest Additions Version: 7.1.6
    default: VirtualBox Version: 7.0
==> default: Setting hostname...
==> default: Rsyncing folder: /tmp/wazuh-virtual-machines/ova/ => /tmp
==> default:   - Exclude: [".vagrant/", "output"]
==> default: Running provisioner: shell...
    default: Running: /tmp/vagrant-shell20250213-1661875-ic8ai2.sh
    default: INSTALLATION_ASSISTANT_BRANCH: v4.11.0-beta1
    default: WVM_BRANCH: bug/202-wazuh-dashboard-shows-errors-in-4110-beta-1-ova
    default: PACKAGES_REPOSITORY: dev
    default: DEBUG: no
    default: Waiting for process with pid 2251 to finish.
    default: Amazon Linux 2023 Kernel Livepatch repository    10 kB/s |  14 kB     00:01
    default: Package git-2.47.1-1.amzn2023.0.2.x86_64 is already installed.
    default: Dependencies resolved.
    default: Nothing to do.
    default: Complete!
    default: Cloning into '/home/ec2-user/wazuh-virtual-machines'...
    default: Cloning into '/home/ec2-user/wazuh-installation-assistant'...
    default: Note: switching to 'v4.11.0-beta1'.
    default: 
    default: You are in 'detached HEAD' state. You can look around, make experimental
    default: changes and commit them, and you can discard any commits you make in this
    default: state without impacting any branches by switching back to a branch.
    default: 
    default: If you want to create a new branch to retain commits you create, you may
    default: do so (now or later) by using -c with the switch command. Example:
    default: 
    default:   git switch -c <new-branch-name>
    default: 
    default: Or undo this operation with:
    default: 
    default:   git switch -
    default: 
    default: Turn off this advice by setting config variable advice.detachedHead to false
    default: 
    default: HEAD is now at b0ccbda Merge pull request #236 from wazuh/Add-last-stage-beta1-to-4.11.0
    default: Switched to a new branch 'bug/202-wazuh-dashboard-shows-errors-in-4110-beta-1-ova'
    default: branch 'bug/202-wazuh-dashboard-shows-errors-in-4110-beta-1-ova' set up to track 'origin/bug/202-wazuh-dashboard-shows-errors-in-4110-beta-1-ova'.
    default: Using dev packages
    default: Configuring system
    default: Upgrading the system. This may take a while ...
    default: Last metadata expiration check: 0:00:08 ago on Thu Feb 13 23:13:07 2025.
    default: Dependencies resolved.
    default: Nothing to do.
    default: Complete!
    default: Last metadata expiration check: 0:00:10 ago on Thu Feb 13 23:13:07 2025.
    default: Package dracut-102-3.amzn2023.0.1.x86_64 is already installed.
    default: Dependencies resolved.
    default: Nothing to do.
    default: Complete!
    default: dracut[E]: Module 'systemd-pcrphase' depends on 'tpm2-tss', which can't be installed
    default: grep: warning: stray \ before /
    default: grep: warning: stray \ before /
    default: grep: warning: stray \ before /
    default: + mv /home/ec2-user/wazuh-virtual-machines/ova/assets/custom/automatic_set_ram.sh /etc/
    default: + chmod 755 /etc/automatic_set_ram.sh
    default: + mv /home/ec2-user/wazuh-virtual-machines/ova/assets/custom/updateIndexerHeap.service /etc/systemd/system/
    default: + systemctl daemon-reload
    default: + systemctl enable updateIndexerHeap.service
    default: Created symlink /etc/systemd/system/multi-user.target.wants/updateIndexerHeap.service → /etc/systemd/system/updateIndexerHeap.service.
    default: + mv /home/ec2-user/wazuh-virtual-machines/ova/assets/custom/wazuh-starter/wazuh-starter.service /etc/systemd/system/
    default: + mv /home/ec2-user/wazuh-virtual-machines/ova/assets/custom/wazuh-starter/wazuh-starter.timer /etc/systemd/system/
    default: + mv /home/ec2-user/wazuh-virtual-machines/ova/assets/custom/wazuh-starter/wazuh-starter.sh /etc/.wazuh-starter.sh
    default: + chmod 755 /etc/.wazuh-starter.sh
    default: + systemctl daemon-reload
    default: + systemctl enable wazuh-starter.timer
    default: Created symlink /etc/systemd/system/timers.target.wants/wazuh-starter.timer → /etc/systemd/system/wazuh-starter.timer.
    default: + systemctl enable wazuh-starter.service
    default: Created symlink /etc/systemd/system/multi-user.target.wants/wazuh-starter.service → /etc/systemd/system/wazuh-starter.service.
    default: + set +x
    default: 
    default: if [[ "$(tty)" == /dev/tty* ]]; then
    default:     cat /usr/lib/motd.d/40-wazuh-banner
    default: fi
    default: Editing installation script
    default: Installing Wazuh central components
    default: 13/02/2025 23:13:57 INFO: Starting Wazuh installation assistant. Wazuh version: 4.11.0 (x86_64/AMD64)
    default: 13/02/2025 23:13:57 INFO: Verbose logging redirected to /var/log/wazuh-install.log
    default: 13/02/2025 23:13:57 INFO: Verifying that your system meets the recommended minimum hardware requirements.
    default: 13/02/2025 23:13:57 INFO: Wazuh web interface port will be 443.
    default: 13/02/2025 23:13:58 INFO: Wazuh development repository added.
    default: 13/02/2025 23:13:58 INFO: --- Configuration files ---
    default: 13/02/2025 23:13:58 INFO: Generating configuration files.
    default: 13/02/2025 23:13:59 INFO: Generating the root certificate.
    default: 13/02/2025 23:13:59 INFO: Generating Admin certificates.
    default: 13/02/2025 23:14:00 INFO: Generating Wazuh indexer certificates.
    default: 13/02/2025 23:14:00 INFO: Generating Filebeat certificates.
    default: 13/02/2025 23:14:00 INFO: Generating Wazuh dashboard certificates.
    default: 13/02/2025 23:14:01 INFO: Created wazuh-install-files.tar. It contains the Wazuh cluster key, certificates, and passwords necessary for installation.
    default: 13/02/2025 23:14:01 INFO: --- Wazuh indexer ---
    default: 13/02/2025 23:14:01 INFO: Starting Wazuh indexer installation.
    default: 13/02/2025 23:17:03 INFO: Wazuh indexer installation finished.
    default: 13/02/2025 23:17:03 INFO: Wazuh indexer post-install configuration finished.
    default: 13/02/2025 23:17:03 INFO: Starting service wazuh-indexer.
    default: 13/02/2025 23:17:13 INFO: wazuh-indexer service started.
    default: 13/02/2025 23:17:13 INFO: Initializing Wazuh indexer cluster security settings.
    default: 13/02/2025 23:17:15 INFO: Wazuh indexer cluster security configuration initialized.
    default: 13/02/2025 23:17:15 INFO: Wazuh indexer cluster initialized.
    default: 13/02/2025 23:17:15 INFO: --- Wazuh server ---
    default: 13/02/2025 23:17:15 INFO: Starting the Wazuh manager installation.
    default: 13/02/2025 23:18:53 INFO: Wazuh manager installation finished.
    default: 13/02/2025 23:18:53 INFO: Wazuh manager vulnerability detection configuration finished.
    default: 13/02/2025 23:18:53 INFO: Starting service wazuh-manager.
    default: 13/02/2025 23:19:05 INFO: wazuh-manager service started.
    default: 13/02/2025 23:19:05 INFO: Starting Filebeat installation.
    default: 13/02/2025 23:19:34 INFO: Filebeat installation finished.
    default: 13/02/2025 23:19:36 INFO: Filebeat post-install configuration finished.
    default: 13/02/2025 23:19:36 INFO: Starting service filebeat.
    default: 13/02/2025 23:19:37 INFO: filebeat service started.
    default: 13/02/2025 23:19:37 INFO: --- Wazuh dashboard ---
    default: 13/02/2025 23:19:37 INFO: Starting Wazuh dashboard installation.
    default: 13/02/2025 23:21:27 INFO: Wazuh dashboard installation finished.
    default: 13/02/2025 23:21:27 INFO: Wazuh dashboard post-install configuration finished.
    default: 13/02/2025 23:21:27 INFO: Starting service wazuh-dashboard.
    default: 13/02/2025 23:21:27 INFO: wazuh-dashboard service started.
    default: 13/02/2025 23:21:28 INFO: Updating the internal users.
    default: 13/02/2025 23:21:30 INFO: A backup of the internal users has been saved in the /etc/wazuh-indexer/internalusers-backup folder.
    default: 13/02/2025 23:21:39 INFO: The filebeat.yml file has been updated to use the Filebeat Keystore username and password.
    default: 13/02/2025 23:21:58 INFO: Initializing Wazuh dashboard web application.
    default: 13/02/2025 23:21:58 INFO: Wazuh dashboard web application not yet initialized. Waiting...
    default: 13/02/2025 23:22:14 INFO: Wazuh dashboard web application not yet initialized. Waiting...
    default: 13/02/2025 23:22:29 INFO: Wazuh dashboard web application initialized.
    default: 13/02/2025 23:22:29 INFO: --- Summary ---
    default: 13/02/2025 23:22:29 INFO: You can access the web interface https://<wazuh-dashboard-ip>:443
    default:     User: admin
    default:     Password: admin
    default: 13/02/2025 23:22:29 INFO: Installation finished.
    default: Stopping Filebeat and Wazuh Manager
    default: Deleting indexes
    default:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    default:                                  Dload  Upload   Total   Spent    Left  Speed
100    21  100    21    0     0    466      0 --:--:-- --:--:-- --:--:--   466
    default:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    default:                                  Dload  Upload   Total   Spent    Left  Speed
100    21  100    21    0     0   2416      0 --:--:-- --:--:-- --:--:--  2625
    default:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    default:                                  Dload  Upload   Total   Spent    Left  Speed
100    21  100    21    0     0    818      0 --:--:-- --:--:-- --:--:--   840
    default:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    default:                                  Dload  Upload   Total   Spent    Left  Speed
100    21  100    21    0     0   2866      0 --:--:-- --:--:-- --:--:--  3000
    default:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
    default:                                  Dload  Upload   Total   Spent    Left  Speed
100    21  100    21    0     0    778      0 --:--:-- --:--:-- --:--:--   807
    default: {"acknowledged":true}{"acknowledged":true}{"acknowledged":true}{"acknowledged":true}{"acknowledged":true}Recreating empty indexes
    default: **************************************************************************
    default: ** This tool will be deprecated in the next major release of OpenSearch **
    default: ** https://github.com/opensearch-project/security/issues/1755           **
    default: **************************************************************************
    default: Security Admin v7
    default: Will connect to 127.0.0.1:9200 ... done
    default: Connected as "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
    default: OpenSearch Version: 2.16.0
    default: Contacting opensearch cluster 'opensearch' and wait for YELLOW clusterstate ...
    default: Clustername: wazuh-cluster
    default: Clusterstate: GREEN
    default: Number of nodes: 1
    default: Number of data nodes: 1
    default: .opendistro_security index already exists, so we do not need to create one.
    default: Populate config from /etc/wazuh-indexer/opensearch-security/
    default: Will update '/config' with /etc/wazuh-indexer/opensearch-security/config.yml
    default:    SUCC: Configuration for 'config' created or updated
    default: Will update '/roles' with /etc/wazuh-indexer/opensearch-security/roles.yml
    default:    SUCC: Configuration for 'roles' created or updated
    default: Will update '/rolesmapping' with /etc/wazuh-indexer/opensearch-security/roles_mapping.yml
    default:    SUCC: Configuration for 'rolesmapping' created or updated
    default: Will update '/internalusers' with /etc/wazuh-indexer/opensearch-security/internal_users.yml
    default:    SUCC: Configuration for 'internalusers' created or updated
    default: Will update '/actiongroups' with /etc/wazuh-indexer/opensearch-security/action_groups.yml
    default:    SUCC: Configuration for 'actiongroups' created or updated
    default: Will update '/tenants' with /etc/wazuh-indexer/opensearch-security/tenants.yml
    default:    SUCC: Configuration for 'tenants' created or updated
    default: Will update '/nodesdn' with /etc/wazuh-indexer/opensearch-security/nodes_dn.yml
    default:    SUCC: Configuration for 'nodesdn' created or updated
    default: Will update '/whitelist' with /etc/wazuh-indexer/opensearch-security/whitelist.yml
    default:    SUCC: Configuration for 'whitelist' created or updated
    default: Will update '/audit' with /etc/wazuh-indexer/opensearch-security/audit.yml
    default:    SUCC: Configuration for 'audit' created or updated
    default: Will update '/allowlist' with /etc/wazuh-indexer/opensearch-security/allowlist.yml
    default:    SUCC: Configuration for 'allowlist' created or updated
    default: SUCC: Expected 10 config types for node {"updated_config_types":["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","actiongroups","config","internalusers"],"updated_config_size":10,"message":null} is 10 (["allowlist","tenants","rolesmapping","nodesdn","audit","roles","whitelist","actiongroups","config","internalusers"]) due to: null
    default: Done with success
    default: Stopping Wazuh indexer and Wazuh dashboard
    default: Removed "/etc/systemd/system/multi-user.target.wants/wazuh-manager.service".
    default: Removed "/etc/systemd/system/multi-user.target.wants/wazuh-dashboard.service".
    default: Cleaning system
    default: 24 files removed
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: 0 files removed
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
    default: shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
==> default: Running provisioner: shell...
    default: Running: /tmp/vagrant-shell20250213-1661875-1oz2mn0.sh
==> default: Attempting graceful shutdown of VM...
    default: Guest communication could not be established! This is usually because
    default: SSH is not running, the authentication information was changed,
    default: or some other networking issue. Vagrant will force halt, if
    default: capable.
==> default: Forcing shutdown of VM...
Exporting ova
0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
Successfully exported 1 machine(s).
==> default: Destroying VM and associated drives...
wazuh-4.11.0.ovf
wazuh-4.11.0-disk001.vmdk
Setting up ova for VMware ESXi
Standarizing OVA
Setting OVA to default
wazuh-4.11.0.ovf
wazuh-4.11.0-disk001.vmdk
OVF extracted
mv: '/tmp/wazuh-virtual-machines/ova/new-ova/wazuh-4.11.0.ovf' and '/tmp/wazuh-virtual-machines/ova/new-ova/wazuh-4.11.0.ovf' are the same file
Files renamed
OVF Version changed
OVF Size changed
Manifest changed
wazuh-4.11.0.ovf
wazuh-4.11.0-disk-1.vmdk
wazuh-4.11.0.mf
New OVA created
Cleaned temporary directory
Process finished
==> default: VM not created. Moving on...

```

![Screenshot_20250213_203317](https://github.com/user-attachments/assets/725ad4b2-fb26-4e4a-a856-c4d003d11b36)

## Wazuh dashboard status

```console
cbordon@cbordon-MS-7C88:~$ ssh wazuh-user@192.168.1.24
The authenticity of host '192.168.1.24 (192.168.1.24)' can't be established.
ECDSA key fingerprint is SHA256:qlzIwb1+1Z6vL3n9h0DN98FIkgvZ/Fo3mlQUjb0MTUg.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '192.168.1.24' (ECDSA) to the list of known hosts.
wazuh-user@192.168.1.24's password: 
wwwwww.           wwwwwww.          wwwwwww.
wwwwwww.          wwwwwww.          wwwwwww.
 wwwwww.         wwwwwwwww.        wwwwwww.
 wwwwwww.        wwwwwwwww.        wwwwwww.
  wwwwww.       wwwwwwwwwww.      wwwwwww.
  wwwwwww.      wwwwwwwwwww.      wwwwwww.
   wwwwww.     wwwwww.wwwwww.    wwwwwww.
   wwwwwww.    wwwww. wwwwww.    wwwwwww.
    wwwwww.   wwwwww.  wwwwww.  wwwwwww.
    wwwwwww.  wwwww.   wwwwww.  wwwwwww.
     wwwwww. wwwwww.    wwwwww.wwwwwww.
     wwwwwww.wwwww.     wwwwww.wwwwwww.
      wwwwwwwwwwww.      wwwwwwwwwwww.
      wwwwwwwwwww.       wwwwwwwwwwww.      oooooo
       wwwwwwwwww.        wwwwwwwwww.      oooooooo
       wwwwwwwww.         wwwwwwwwww.     oooooooooo
        wwwwwwww.          wwwwwwww.      oooooooooo
        wwwwwww.           wwwwwwww.       oooooooo
         wwwwww.            wwwwww.         oooooo


         WAZUH Open Source Security Platform
                  https://wazuh.com
Last login: Thu Feb 13 23:31:33 2025
[wazuh-user@wazuh-server ~]$ systemctl status wazuh-dashboard.service 
● wazuh-dashboard.service - wazuh-dashboard
     Loaded: loaded (/etc/systemd/system/wazuh-dashboard.service; disabled; preset: disabled)
     Active: active (running) since Thu 2025-02-13 23:31:59 UTC; 11s ago
   Main PID: 3410 (node)
      Tasks: 11 (limit: 9468)
     Memory: 400.5M
        CPU: 7.098s
     CGroup: /system.slice/wazuh-dashboard.service
             └─3410 /usr/share/wazuh-dashboard/node/bin/node --no-warnings --max-http-header-size=65536 --unhandled-rejections=warn /usr/share/wazuh-dashboard/src/cli/dist
```
## Wazuh manager status

```console
[wazuh-user@wazuh-server ~]$ systemctl status wazuh-manager.service 
● wazuh-manager.service - Wazuh manager
     Loaded: loaded (/usr/lib/systemd/system/wazuh-manager.service; enabled; preset: disabled)
     Active: active (running) since Thu 2025-02-13 23:31:59 UTC; 20s ago
      Tasks: 174 (limit: 9468)
     Memory: 982.9M
        CPU: 27.127s
     CGroup: /system.slice/wazuh-manager.service
             ├─2514 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─2515 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─2518 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─2521 /var/ossec/framework/python/bin/python3 /var/ossec/api/scripts/wazuh_apid.py
             ├─2563 /var/ossec/bin/wazuh-authd
             ├─2577 /var/ossec/bin/wazuh-db
             ├─2610 /var/ossec/bin/wazuh-execd
             ├─2622 /var/ossec/bin/wazuh-analysisd
             ├─2684 /var/ossec/bin/wazuh-syscheckd
             ├─2699 /var/ossec/bin/wazuh-remoted
             ├─2734 /var/ossec/bin/wazuh-logcollector
             ├─2755 /var/ossec/bin/wazuh-monitord
             ├─2766 /var/ossec/bin/wazuh-modulesd
             └─3448 /usr/bin/python3 /usr/bin/dnf list "installed|" grep sudo

```

## Wazuh indexer status

```console
[wazuh-user@wazuh-server ~]$ systemctl status wazuh-indexer
● wazuh-indexer.service - wazuh-indexer
     Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; enabled; preset: disabled)
     Active: active (running) since Thu 2025-02-13 23:31:43 UTC; 42s ago
       Docs: https://documentation.wazuh.com
   Main PID: 2099 (java)
      Tasks: 95 (limit: 9468)
     Memory: 4.5G
        CPU: 50.283s
     CGroup: /system.slice/wazuh-indexer.service
             └─2099 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8>


```

## Wazuh dashboard logs

```console
[wazuh-user@wazuh-server ~]$ sudo su -
[root@wazuh-server ~]# journalctl -r -u wazuh-dashboard | grep -i -E "error|critical|fatal"
[root@wazuh-server ~]# ls -la /etc/systemd/system/wazuh-*
-rw-r-----. 1 root root 341 Feb  7 11:12 /etc/systemd/system/wazuh-dashboard.service
[root@wazuh-server ~]#
```

![Screenshot_20250213_203522](https://github.com/user-attachments/assets/8b07d06b-5f87-4690-bf72-aef486afd7a7)
