### PR TITLE
Adapt automation that uses the allocator

### DIFF
--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -196,28 +196,28 @@ jobs:
           builder_args='$builder_args' \
           debug=yes" ${{ inputs.debug }}
 
-      - name: Getting OVA from AWS instance
-        run: |
-          scp -P ${{ env.ansible_port }} -i ${{ env.ansible_ssh_private_key_file }} ${{ env.ansible_user }}@${{ env.ansible_host }}:/home/ec2-user/${{ env.FILENAME_OVA }} /tmp/${{ env.FILENAME_OVA }}
-
-      - name: Standarizing OVA
-        run: |
-          sed -i "s|ovf:capacity=\"40\"|ovf:capacity=\"50\"|g" ova/wazuh_ovf_template
-          bash ova/setOVADefault.sh "ova/" "/tmp/${{ env.FILENAME_OVA }}" "/tmp/${{ env.FILENAME_OVA }}" "ova/wazuh_ovf_template" "${{ env.WAZUH_VERSION }}"
-
-      - name: Exporting OVA to final repository
-        run: |
-          aws s3 cp --quiet /tmp/${{ env.FILENAME_OVA }} s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_OVA }}
-          s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_OVA }}"
-          echo "S3 OVA URI: ${s3uri}"
-
-      - name: Generating sha512 file
-        if: ${{ inputs.checksum == true }}
-        run: |
-          sha512sum /tmp/${{ env.FILENAME_OVA }} > /tmp/${{ env.FILENAME_SHA }}
-          aws s3 cp --quiet /tmp/${{ env.FILENAME_SHA }} s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_SHA }}
-          s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_SHA }}"
-          echo "S3 sha512 OVA URI: ${s3uri}"
+      #- name: Getting OVA from AWS instance
+      #  run: |
+      #    scp -P ${{ env.ansible_port }} -i ${{ env.ansible_ssh_private_key_file }} ${{ env.ansible_user }}@${{ env.ansible_host }}:/home/ec2-user/${{ env.FILENAME_OVA }} /tmp/${{ env.FILENAME_OVA }}
+#
+      #- name: Standarizing OVA
+      #  run: |
+      #    sed -i "s|ovf:capacity=\"40\"|ovf:capacity=\"50\"|g" ova/wazuh_ovf_template
+      #    bash ova/setOVADefault.sh "ova/" "/tmp/${{ env.FILENAME_OVA }}" "/tmp/${{ env.FILENAME_OVA }}" "ova/wazuh_ovf_template" "${{ env.WAZUH_VERSION }}"
+#
+      #- name: Exporting OVA to final repository
+      #  run: |
+      #    aws s3 cp --quiet /tmp/${{ env.FILENAME_OVA }} s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_OVA }}
+      #    s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_OVA }}"
+      #    echo "S3 OVA URI: ${s3uri}"
+#
+      #- name: Generating sha512 file
+      #  if: ${{ inputs.checksum == true }}
+      #  run: |
+      #    sha512sum /tmp/${{ env.FILENAME_OVA }} > /tmp/${{ env.FILENAME_SHA }}
+      #    aws s3 cp --quiet /tmp/${{ env.FILENAME_SHA }} s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_SHA }}
+      #    s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_SHA }}"
+      #    echo "S3 sha512 OVA URI: ${s3uri}"
 
       - name: Delete allocated VM
         if: always() && steps.alloc_vm.outcome == 'success'

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -196,28 +196,28 @@ jobs:
           builder_args='$builder_args' \
           debug=yes" ${{ inputs.debug }}
 
-      #- name: Getting OVA from AWS instance
-      #  run: |
-      #    scp -P ${{ env.ansible_port }} -i ${{ env.ansible_ssh_private_key_file }} ${{ env.ansible_user }}@${{ env.ansible_host }}:/home/ec2-user/${{ env.FILENAME_OVA }} /tmp/${{ env.FILENAME_OVA }}
-#
-      #- name: Standarizing OVA
-      #  run: |
-      #    sed -i "s|ovf:capacity=\"40\"|ovf:capacity=\"50\"|g" ova/wazuh_ovf_template
-      #    bash ova/setOVADefault.sh "ova/" "/tmp/${{ env.FILENAME_OVA }}" "/tmp/${{ env.FILENAME_OVA }}" "ova/wazuh_ovf_template" "${{ env.WAZUH_VERSION }}"
-#
-      #- name: Exporting OVA to final repository
-      #  run: |
-      #    aws s3 cp --quiet /tmp/${{ env.FILENAME_OVA }} s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_OVA }}
-      #    s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_OVA }}"
-      #    echo "S3 OVA URI: ${s3uri}"
-#
-      #- name: Generating sha512 file
-      #  if: ${{ inputs.checksum == true }}
-      #  run: |
-      #    sha512sum /tmp/${{ env.FILENAME_OVA }} > /tmp/${{ env.FILENAME_SHA }}
-      #    aws s3 cp --quiet /tmp/${{ env.FILENAME_SHA }} s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_SHA }}
-      #    s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_SHA }}"
-      #    echo "S3 sha512 OVA URI: ${s3uri}"
+      - name: Getting OVA from AWS instance
+        run: |
+          scp -P ${{ env.ansible_port }} -i ${{ env.ansible_ssh_private_key_file }} ${{ env.ansible_user }}@${{ env.ansible_host }}:/home/ec2-user/${{ env.FILENAME_OVA }} /tmp/${{ env.FILENAME_OVA }}
+
+      - name: Standarizing OVA
+        run: |
+          sed -i "s|ovf:capacity=\"40\"|ovf:capacity=\"50\"|g" ova/wazuh_ovf_template
+          bash ova/setOVADefault.sh "ova/" "/tmp/${{ env.FILENAME_OVA }}" "/tmp/${{ env.FILENAME_OVA }}" "ova/wazuh_ovf_template" "${{ env.WAZUH_VERSION }}"
+
+      - name: Exporting OVA to final repository
+        run: |
+          aws s3 cp --quiet /tmp/${{ env.FILENAME_OVA }} s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_OVA }}
+          s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_OVA }}"
+          echo "S3 OVA URI: ${s3uri}"
+
+      - name: Generating sha512 file
+        if: ${{ inputs.checksum == true }}
+        run: |
+          sha512sum /tmp/${{ env.FILENAME_OVA }} > /tmp/${{ env.FILENAME_SHA }}
+          aws s3 cp --quiet /tmp/${{ env.FILENAME_SHA }} s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_SHA }}
+          s3uri="s3://${{ env.S3_BUCKET }}/${{ env.S3_PATH }}/${{ env.FILENAME_SHA }}"
+          echo "S3 sha512 OVA URI: ${s3uri}"
 
       - name: Delete allocated VM
         if: always() && steps.alloc_vm.outcome == 'success'

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -156,16 +156,20 @@ jobs:
           python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size ${{ env.INSTANCE_TYPE }} --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
             --track-output ${{ env.ALLOCATOR_PATH }}/track.yml --inventory-output ${{ env.ALLOCATOR_PATH }}/inventory.yml --instance-name gha_${{ github.run_id }}_ova_build \
             --label-team devops --label-termination-date 1d
-          sed 's/: */=/g' ${{ env.ALLOCATOR_PATH }}/inventory.yml > ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
-          sed -n 's/^identifier: \(.*\)$/identifier=\1/p' ${{ env.ALLOCATOR_PATH }}/track.yml >> ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
-          source ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
+          sed -n '/hosts:/,/^[^ ]/p' ${{ env.ALLOCATOR_PATH }}/inventory.yml | grep "ansible_" | sed 's/^[ ]*//g' > ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
+
+          sed 's/: */=/g' ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml > ${{ env.ALLOCATOR_PATH }}/inventory_vars.yml
+          sed -n 's/^identifier: \(.*\)$/identifier=\1/p' ${{ env.ALLOCATOR_PATH }}/track.yml >> ${{ env.ALLOCATOR_PATH }}/inventory_vars.yml
+          source ${{ env.ALLOCATOR_PATH }}/inventory_vars.yml
+
+          # Enmascarar las variables sensibles
           echo "::add-mask::$ansible_host"
           echo "::add-mask::$ansible_port"
           echo "::add-mask::$ansible_user"
           echo "::add-mask::$ansible_ssh_private_key_file"
           echo "::add-mask::$ansible_ssh_common_args"
           echo "::add-mask::$identifier"
-          cat "${{ env.ALLOCATOR_PATH }}/inventory_mod.yml" >> $GITHUB_ENV;
+          cat "${{ env.ALLOCATOR_PATH }}/inventory_vars.yml" >> $GITHUB_ENV
 
       - name: Generate inventory
         run: |

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -141,89 +141,89 @@ jobs:
           "${{ inputs.debug }}"
 
 
-      - name: Stop instance
-        run: |
-          aws ec2 stop-instances --instance-ids ${{ env.identifier }}
-
-      - name: Check EC2 instance status until stopped
-        id: check_status
-        run: |
-          TIMEOUT=120
-          INTERVAL=2
-          ELAPSED=0
-
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            STATUS=$(aws ec2 describe-instances --instance-ids ${{ env.identifier }} --query 'Reservations[*].Instances[*].State.Name' --output text)
-            echo "Instance status: $STATUS"
-
-            if [ "$STATUS" == "stopped" ]; then
-              echo "Instance is stopped."
-              break
-            fi
-
-            echo "Waiting for instance to stop..."
-            sleep $INTERVAL
-            ELAPSED=$((ELAPSED + INTERVAL))
-          done
-
-          if [ $ELAPSED -ge $TIMEOUT ]; then
-            echo "Timeout reached. The instance is still not stopped."
-            exit 1
-          fi
-
-      - name: Build AMI from instance
-        if: success()
-        run: |
-          AMI_NAME="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.ami_revision }}"
-          aws ec2 create-image --instance-id ${{ env.identifier }} --name "$AMI_NAME" --no-reboot
-          AMI_ID=$(aws ec2 describe-images --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].ImageId' --output text)
-          echo "AMI_ID=$AMI_ID" >> $GITHUB_ENV
-          echo "AMI creation started with name $AMI_NAME"
-
-      - name: Check AMI status until available
-        id: check_ami_status
-        run: |
-          TIMEOUT=1800
-          INTERVAL=30
-          ELAPSED=0
-
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            STATUS=$(aws ec2 describe-images --image-ids ${{ env.AMI_ID }} --query 'Images[*].State' --output text)
-            echo "AMI status: $STATUS"
-
-            if [ "$STATUS" == "available" ]; then
-              echo "AMI is available."
-              break
-            fi
-
-            echo "Waiting for AMI ${{ env.AMI_ID }} to be available..."
-            sleep $INTERVAL
-            ELAPSED=$((ELAPSED + INTERVAL))
-          done
-
-          if [ $ELAPSED -ge $TIMEOUT ]; then
-            echo "Timeout reached. The AMI ${{ env.AMI_ID }} is still not available."
-            exit 1
-          fi
-
-      - name: Tag AMI
-        if: success()
-        run: |
-          aws ec2 create-tags --resources ${{ env.AMI_ID }} --tags Key=Name,Value="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.ami_revision }}"
+      #- name: Stop instance
+      #  run: |
+      #    aws ec2 stop-instances --instance-ids ${{ env.identifier }}
+#
+      #- name: Check EC2 instance status until stopped
+      #  id: check_status
+      #  run: |
+      #    TIMEOUT=120
+      #    INTERVAL=2
+      #    ELAPSED=0
+#
+      #    while [ $ELAPSED -lt $TIMEOUT ]; do
+      #      STATUS=$(aws ec2 describe-instances --instance-ids ${{ env.identifier }} --query 'Reservations[*].Instances[*].State.Name' --output text)
+      #      echo "Instance status: $STATUS"
+#
+      #      if [ "$STATUS" == "stopped" ]; then
+      #        echo "Instance is stopped."
+      #        break
+      #      fi
+#
+      #      echo "Waiting for instance to stop..."
+      #      sleep $INTERVAL
+      #      ELAPSED=$((ELAPSED + INTERVAL))
+      #    done
+#
+      #    if [ $ELAPSED -ge $TIMEOUT ]; then
+      #      echo "Timeout reached. The instance is still not stopped."
+      #      exit 1
+      #    fi
+#
+      #- name: Build AMI from instance
+      #  if: success()
+      #  run: |
+      #    AMI_NAME="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.ami_revision }}"
+      #    aws ec2 create-image --instance-id ${{ env.identifier }} --name "$AMI_NAME" --no-reboot
+      #    AMI_ID=$(aws ec2 describe-images --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].ImageId' --output text)
+      #    echo "AMI_ID=$AMI_ID" >> $GITHUB_ENV
+      #    echo "AMI creation started with name $AMI_NAME"
+#
+      #- name: Check AMI status until available
+      #  id: check_ami_status
+      #  run: |
+      #    TIMEOUT=1800
+      #    INTERVAL=30
+      #    ELAPSED=0
+#
+      #    while [ $ELAPSED -lt $TIMEOUT ]; do
+      #      STATUS=$(aws ec2 describe-images --image-ids ${{ env.AMI_ID }} --query 'Images[*].State' --output text)
+      #      echo "AMI status: $STATUS"
+#
+      #      if [ "$STATUS" == "available" ]; then
+      #        echo "AMI is available."
+      #        break
+      #      fi
+#
+      #      echo "Waiting for AMI ${{ env.AMI_ID }} to be available..."
+      #      sleep $INTERVAL
+      #      ELAPSED=$((ELAPSED + INTERVAL))
+      #    done
+#
+      #    if [ $ELAPSED -ge $TIMEOUT ]; then
+      #      echo "Timeout reached. The AMI ${{ env.AMI_ID }} is still not available."
+      #      exit 1
+      #    fi
+#
+      #- name: Tag AMI
+      #  if: success()
+      #  run: |
+      #    aws ec2 create-tags --resources ${{ env.AMI_ID }} --tags Key=Name,Value="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.ami_revision }}"
 
       - name: Delete allocated VM
         if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.destroy == true
         run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output ${{ env.ALLOCATOR_PATH }}/track.yml
 
-      - name: Compress Allocator directory
-        id: generate_artifacts
-        if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.destroy == false
-        run: zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r ${{ env.ALLOCATOR_PATH }}.zip ${{ env.ALLOCATOR_PATH }}
-        continue-on-error: true
-
-      - name: Upload Allocator directory as artifact
-        if: always() && steps.generate_artifacts.outcome == 'success'
-        uses: actions/upload-artifact@v4
-        with:
-          name: instance_info
-          path: ${{ env.ALLOCATOR_PATH }}.zip
+      #- name: Compress Allocator directory
+      #  id: generate_artifacts
+      #  if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.destroy == false
+      #  run: zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r ${{ env.ALLOCATOR_PATH }}.zip ${{ env.ALLOCATOR_PATH }}
+      #  continue-on-error: true
+#
+      #- name: Upload Allocator directory as artifact
+      #  if: always() && steps.generate_artifacts.outcome == 'success'
+      #  uses: actions/upload-artifact@v4
+      #  with:
+      #    name: instance_info
+      #    path: ${{ env.ALLOCATOR_PATH }}.zip

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -116,22 +116,25 @@ jobs:
           python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
             --track-output ${{ env.ALLOCATOR_PATH }}/track.yml --inventory-output ${{ env.ALLOCATOR_PATH }}/inventory.yml --instance-name gha_${{ github.run_id }}_ami_build \
             --label-team devops --label-termination-date 1d
-          sed -n '/ansible_/p' ${{ env.ALLOCATOR_PATH }}/inventory.yml | sed 's/^[ ]*//g' | sed 's/: */=/g' > ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
-          sed -n 's/^identifier: \(.*\)$/identifier=\1/p' ${{ env.ALLOCATOR_PATH }}/track.yml >> ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
+          sed -n '/hosts:/,/^[^ ]/p' ${{ env.ALLOCATOR_PATH }}/inventory.yml | grep "ansible_" | sed 's/^[ ]*//g' > ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
 
-          source ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
+          sed 's/: */=/g' ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml > ${{ env.ALLOCATOR_PATH }}/inventory_vars.yml
+          sed -n 's/^identifier: \(.*\)$/identifier=\1/p' ${{ env.ALLOCATOR_PATH }}/track.yml >> ${{ env.ALLOCATOR_PATH }}/inventory_vars.yml
+          source ${{ env.ALLOCATOR_PATH }}/inventory_vars.yml
+
           echo "::add-mask::$ansible_host"
           echo "::add-mask::$ansible_port"
           echo "::add-mask::$ansible_user"
           echo "::add-mask::$ansible_ssh_private_key_file"
           echo "::add-mask::$ansible_ssh_common_args"
           echo "::add-mask::$identifier"
-          cat "${{ env.ALLOCATOR_PATH }}/inventory_mod.yml" >> $GITHUB_ENV
+
+          cat "${{ env.ALLOCATOR_PATH }}/inventory_vars.yml" >> $GITHUB_ENV
 
       - name: Generate inventory
         run: |
           echo "[gha_instance]" > ${{ env.ALLOCATOR_PATH }}/inventory_ansible.ini
-          echo "ansible_port=${{ env.ansible_port }} ansible_user=${{ env.ansible_user }} ansible_ssh_private_key_file=${{ env.ansible_ssh_private_key_file }} ansible_ssh_common_args='${{ env.ansible_ssh_common_args }}'" >> ${{ env.ALLOCATOR_PATH }}/inventory_ansible.ini
+          echo "${{ env.ansible_host }} ansible_port=${{ env.ansible_port }} ansible_user=${{ env.ansible_user }} ansible_ssh_private_key_file=${{ env.ansible_ssh_private_key_file }} ansible_ssh_common_args='${{ env.ansible_ssh_common_args }}'" >> ${{ env.ALLOCATOR_PATH }}/inventory_ansible.ini
 
       - name: Run Ansible playbook to install Wazuh components
         run: |

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -116,8 +116,9 @@ jobs:
           python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
             --track-output ${{ env.ALLOCATOR_PATH }}/track.yml --inventory-output ${{ env.ALLOCATOR_PATH }}/inventory.yml --instance-name gha_${{ github.run_id }}_ami_build \
             --label-team devops --label-termination-date 1d
-          sed 's/: */=/g' ${{ env.ALLOCATOR_PATH }}/inventory.yml > ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
+          sed -n '/ansible_/p' ${{ env.ALLOCATOR_PATH }}/inventory.yml | sed 's/^[ ]*//g' | sed 's/: */=/g' > ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
           sed -n 's/^identifier: \(.*\)$/identifier=\1/p' ${{ env.ALLOCATOR_PATH }}/track.yml >> ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
+
           source ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
           echo "::add-mask::$ansible_host"
           echo "::add-mask::$ansible_port"
@@ -125,13 +126,12 @@ jobs:
           echo "::add-mask::$ansible_ssh_private_key_file"
           echo "::add-mask::$ansible_ssh_common_args"
           echo "::add-mask::$identifier"
-          cat "${{ env.ALLOCATOR_PATH }}/inventory_mod.yml" >> $GITHUB_ENV;
+          cat "${{ env.ALLOCATOR_PATH }}/inventory_mod.yml" >> $GITHUB_ENV
 
       - name: Generate inventory
         run: |
           echo "[gha_instance]" > ${{ env.ALLOCATOR_PATH }}/inventory_ansible.ini
-          echo "${{ env.ansible_host }} ansible_port=${{ env.ansible_port }} ansible_user=${{ env.ansible_user }} ansible_ssh_private_key_file=${{ env.ansible_ssh_private_key_file }} ansible_ssh_common_args='${{ env.ansible_ssh_common_args }}'" >> ${{ env.ALLOCATOR_PATH }}/inventory_ansible.ini
-
+          echo "ansible_port=${{ env.ansible_port }} ansible_user=${{ env.ansible_user }} ansible_ssh_private_key_file=${{ env.ansible_ssh_private_key_file }} ansible_ssh_common_args='${{ env.ansible_ssh_common_args }}'" >> ${{ env.ALLOCATOR_PATH }}/inventory_ansible.ini
 
       - name: Run Ansible playbook to install Wazuh components
         run: |

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -144,89 +144,89 @@ jobs:
           "${{ inputs.debug }}"
 
 
-      #- name: Stop instance
-      #  run: |
-      #    aws ec2 stop-instances --instance-ids ${{ env.identifier }}
-#
-      #- name: Check EC2 instance status until stopped
-      #  id: check_status
-      #  run: |
-      #    TIMEOUT=120
-      #    INTERVAL=2
-      #    ELAPSED=0
-#
-      #    while [ $ELAPSED -lt $TIMEOUT ]; do
-      #      STATUS=$(aws ec2 describe-instances --instance-ids ${{ env.identifier }} --query 'Reservations[*].Instances[*].State.Name' --output text)
-      #      echo "Instance status: $STATUS"
-#
-      #      if [ "$STATUS" == "stopped" ]; then
-      #        echo "Instance is stopped."
-      #        break
-      #      fi
-#
-      #      echo "Waiting for instance to stop..."
-      #      sleep $INTERVAL
-      #      ELAPSED=$((ELAPSED + INTERVAL))
-      #    done
-#
-      #    if [ $ELAPSED -ge $TIMEOUT ]; then
-      #      echo "Timeout reached. The instance is still not stopped."
-      #      exit 1
-      #    fi
-#
-      #- name: Build AMI from instance
-      #  if: success()
-      #  run: |
-      #    AMI_NAME="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.ami_revision }}"
-      #    aws ec2 create-image --instance-id ${{ env.identifier }} --name "$AMI_NAME" --no-reboot
-      #    AMI_ID=$(aws ec2 describe-images --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].ImageId' --output text)
-      #    echo "AMI_ID=$AMI_ID" >> $GITHUB_ENV
-      #    echo "AMI creation started with name $AMI_NAME"
-#
-      #- name: Check AMI status until available
-      #  id: check_ami_status
-      #  run: |
-      #    TIMEOUT=1800
-      #    INTERVAL=30
-      #    ELAPSED=0
-#
-      #    while [ $ELAPSED -lt $TIMEOUT ]; do
-      #      STATUS=$(aws ec2 describe-images --image-ids ${{ env.AMI_ID }} --query 'Images[*].State' --output text)
-      #      echo "AMI status: $STATUS"
-#
-      #      if [ "$STATUS" == "available" ]; then
-      #        echo "AMI is available."
-      #        break
-      #      fi
-#
-      #      echo "Waiting for AMI ${{ env.AMI_ID }} to be available..."
-      #      sleep $INTERVAL
-      #      ELAPSED=$((ELAPSED + INTERVAL))
-      #    done
-#
-      #    if [ $ELAPSED -ge $TIMEOUT ]; then
-      #      echo "Timeout reached. The AMI ${{ env.AMI_ID }} is still not available."
-      #      exit 1
-      #    fi
-#
-      #- name: Tag AMI
-      #  if: success()
-      #  run: |
-      #    aws ec2 create-tags --resources ${{ env.AMI_ID }} --tags Key=Name,Value="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.ami_revision }}"
+      - name: Stop instance
+        run: |
+          aws ec2 stop-instances --instance-ids ${{ env.identifier }}
+
+      - name: Check EC2 instance status until stopped
+        id: check_status
+        run: |
+          TIMEOUT=120
+          INTERVAL=2
+          ELAPSED=0
+
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            STATUS=$(aws ec2 describe-instances --instance-ids ${{ env.identifier }} --query 'Reservations[*].Instances[*].State.Name' --output text)
+            echo "Instance status: $STATUS"
+
+            if [ "$STATUS" == "stopped" ]; then
+              echo "Instance is stopped."
+              break
+            fi
+
+            echo "Waiting for instance to stop..."
+            sleep $INTERVAL
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+            echo "Timeout reached. The instance is still not stopped."
+            exit 1
+          fi
+
+      - name: Build AMI from instance
+        if: success()
+        run: |
+          AMI_NAME="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.ami_revision }}"
+          aws ec2 create-image --instance-id ${{ env.identifier }} --name "$AMI_NAME" --no-reboot
+          AMI_ID=$(aws ec2 describe-images --filters "Name=name,Values=$AMI_NAME" --query 'Images[*].ImageId' --output text)
+          echo "AMI_ID=$AMI_ID" >> $GITHUB_ENV
+          echo "AMI creation started with name $AMI_NAME"
+
+      - name: Check AMI status until available
+        id: check_ami_status
+        run: |
+          TIMEOUT=1800
+          INTERVAL=30
+          ELAPSED=0
+
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            STATUS=$(aws ec2 describe-images --image-ids ${{ env.AMI_ID }} --query 'Images[*].State' --output text)
+            echo "AMI status: $STATUS"
+
+            if [ "$STATUS" == "available" ]; then
+              echo "AMI is available."
+              break
+            fi
+
+            echo "Waiting for AMI ${{ env.AMI_ID }} to be available..."
+            sleep $INTERVAL
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+            echo "Timeout reached. The AMI ${{ env.AMI_ID }} is still not available."
+            exit 1
+          fi
+
+      - name: Tag AMI
+        if: success()
+        run: |
+          aws ec2 create-tags --resources ${{ env.AMI_ID }} --tags Key=Name,Value="Wazuh_v${{ env.WAZUH_VERSION }}${{ inputs.ami_revision }}"
 
       - name: Delete allocated VM
         if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.destroy == true
         run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output ${{ env.ALLOCATOR_PATH }}/track.yml
 
-      #- name: Compress Allocator directory
-      #  id: generate_artifacts
-      #  if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.destroy == false
-      #  run: zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r ${{ env.ALLOCATOR_PATH }}.zip ${{ env.ALLOCATOR_PATH }}
-      #  continue-on-error: true
-#
-      #- name: Upload Allocator directory as artifact
-      #  if: always() && steps.generate_artifacts.outcome == 'success'
-      #  uses: actions/upload-artifact@v4
-      #  with:
-      #    name: instance_info
-      #    path: ${{ env.ALLOCATOR_PATH }}.zip
+      - name: Compress Allocator directory
+        id: generate_artifacts
+        if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.destroy == false
+        run: zip -P "${{ secrets.ZIP_ARTIFACTS_PASSWORD }}" -r ${{ env.ALLOCATOR_PATH }}.zip ${{ env.ALLOCATOR_PATH }}
+        continue-on-error: true
+
+      - name: Upload Allocator directory as artifact
+        if: always() && steps.generate_artifacts.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: instance_info
+          path: ${{ env.ALLOCATOR_PATH }}.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Adapt existing workflows to new allocator YAML inventory ([#220](https://github.com/wazuh/wazuh-virtual-machines/pull/220))
 - Updated VERSION file to the new standard. ([#212](https://github.com/wazuh/wazuh-virtual-machines/pull/212))
 - Change runners in GHA workflows to Ubuntu 22.04 ([#145](https://github.com/wazuh/wazuh-virtual-machines/pull/145))
 


### PR DESCRIPTION
Closes #207

### Description

The goal of this PR is to adapt the repository automation to use the new inventory generated by the allocator.

### Tests

OVA:
https://github.com/wazuh/wazuh-virtual-machines/actions/runs/13464132303/job/37626056152

AMI:
https://github.com/wazuh/wazuh-virtual-machines/actions/runs/13464254706/job/37626460888

The tests are failing, but because it is not feasible to perform the full test due to changes in the different versions, particularly the adaptation of the VERSION.json file, previously this file was VERSION and its structure changed. So the full test cannot be performed since this change was introduced in 4.12.0. For example, the problem is displayed here.

AMI:
https://github.com/wazuh/wazuh-virtual-machines/actions/runs/13464146950/job/37626102861

OVA:
https://github.com/wazuh/wazuh-virtual-machines/actions/runs/13464042428/job/37625759381

But as you can see in the steps, the formatting of the new inventory was taken correctly, since the playbooks are executed with ansible within each generated instance.