### PR TITLE
Remove default virtual-machines reference version from workflow

### DIFF
--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -11,7 +11,6 @@ on:
       wazuh_virtual_machines_reference:
         description: 'Branch or tag of the wazuh-virtual-machines repository'
         required: true
-        default: '4.13.0'
       wazuh_installation_assistant_reference:
         description: 'Branch or tag of the wazuh-installation-assistant repository'
         required: true

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -11,7 +11,6 @@ on:
       wazuh_virtual_machines_reference:
         description: 'Branch or tag of the wazuh-virtual-machines repository'
         required: true
-        default: '4.13.0'
       wazuh_automation_reference:
         description: 'Branch or tag of the wazuh-automation repository'
         required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Deleted
 
-- None
+- Remove default virtual-machines reference version from workflow ([#237](https://github.com/wazuh/wazuh-virtual-machines/pull/237))
 
 ## [4.12.0]
 


### PR DESCRIPTION
# Description

The changes included in this PR aim to remove the default values of variables referencing the Wazuh-virtual-machines repository.

## Related issue

- https://github.com/wazuh/internal-devel-requests/issues/2137