### PR TITLE
Fix obtaining the tag in case of HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Fix obtaining the tag in case the INSTALLATION_ASSISTANT_BRANCH variable contains the HEAD ([#239](https://github.com/wazuh/wazuh-virtual-machines/pull/239))
 
 ### Deleted
 

--- a/ova/generate_ova.sh
+++ b/ova/generate_ova.sh
@@ -250,7 +250,7 @@ main() {
 
         # If the reference is HEAD, get the tag name
         if [ "${INSTALLATION_ASSISTANT_BRANCH}" == "HEAD" ]; then
-            INSTALLATION_ASSISTANT_BRANCH=$(git name-rev --tags --name-only $(git rev-parse HEAD))
+            INSTALLATION_ASSISTANT_BRANCH=$(git describe --tags --exact-match)
         fi
     fi
     if [ "${INSTALLATION_ASSISTANT_BRANCH:0:1}" == "v" ]; then


### PR DESCRIPTION
Closes https://github.com/wazuh/external-devel-requests/issues/5263

### Description

The objective of this PR is to fix the bug when getting the tag in case the INSTALLATION_ASSISTANT_BRANCH variable contains the HEAD

### Test






<details><summary>Version 4.11.1:</summary>

```
$ git clone https://github.com/wazuh/wazuh-virtual-machines && cd wazuh-virtual-machines/ova/ && git checkout v4.11.1
Clonando en 'wazuh-virtual-machines'...
remote: Enumerating objects: 2220, done.
remote: Counting objects: 100% (141/141), done.
remote: Compressing objects: 100% (68/68), done.
remote: Total 2220 (delta 97), reused 94 (delta 71), pack-reused 2079 (from 3)
Recibiendo objetos: 100% (2220/2220), 673.52 KiB | 4.52 MiB/s, listo.
Resolviendo deltas: 100% (1020/1020), listo.
Nota: cambiando a 'v4.11.1'.

Te encuentras en estado 'detached HEAD'. Puedes revisar por aquí, hacer
cambios experimentales y hacer commits, y puedes descartar cualquier
commit que hayas hecho en este estado sin impactar a tu rama realizando
otro checkout.

Si quieres crear una nueva rama para mantener los commits que has creado,
puedes hacerlo (ahora o después) usando -c con el comando checkout. Ejemplo:

  git switch -c <nombre-de-nueva-rama>

O deshacer la operación con:

  git switch -

Desactiva este aviso poniendo la variable de config advice.detachedHead en false

HEAD está ahora en 5dad709 Merge pull request #217 from wazuh/merge-4.11.0-into-4.11.1


$ git describe --tags --exact-match
v4.11.1

$ ./generate_ova.sh 
Building Wazuh OVA version 4.11.1
Cloning Wazuh installation assistant repository
Using v4.11.1 branch of wazuh-installation-assistant repository
Building Wazuh installation assistant from v4.11.1 branch
Version to build: 4.11.1 with production repository
==> default: VM not created. Moving on...
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'al2023' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Box file was not detected as metadata. Adding it directly...
==> default: Adding box 'al2023' (v0) for provider: virtualbox
    default: Downloading: https://packages-dev.wazuh.com/vms/ova/al2023.box
==> default: Successfully added box 'al2023' (v0) for 'virtualbox'!
==> default: Importing base box 'al2023'...
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: vm_wazuh
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: wazuh-user
    default: SSH auth method: private key
    default: Warning: Connection reset. Retrying...
    default: Warning: Remote connection disconnect. Retrying...
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: The guest additions on this VM do not match the installed version of
    default: VirtualBox! In most cases this is fine, but in rare cases it can
    default: prevent things such as shared folders from working properly. If you see
    default: shared folder errors, please make sure the guest additions within the
    default: virtual machine match the version of VirtualBox you have installed on
    default: your host and reload your VM.
    default: 
    default: Guest Additions Version: 7.1.6
    default: VirtualBox Version: 7.0
==> default: Setting hostname...
==> default: Rsyncing folder: /tmp/test/wazuh-virtual-machines/ova/ => /tmp
==> default:   - Exclude: [".vagrant/", "output"]
==> default: Running provisioner: shell...
    default: Running: /tmp/vagrant-shell20250326-761911-z30jha.sh
    default: INSTALLATION_ASSISTANT_BRANCH: v4.11.1
    default: WVM_BRANCH: HEAD
    default: PACKAGES_REPOSITORY: prod
    default: DEBUG: no
    default: Waiting for process with pid 2173 to finish.
    default: Amazon Linux 2023 Kernel Livepatch repository   9.1 kB/s |  14 kB     00:01
    default: Package git-2.47.1-1.amzn2023.0.2.x86_64 is already installed.
    default: Dependencies resolved.
    default: Nothing to do.
    default: Complete!
    default: Cloning into '/home/ec2-user/wazuh-virtual-machines'...
    default: Cloning into '/home/ec2-user/wazuh-installation-assistant'...
    default: Note: switching to 'v4.11.1'.
    default: 
    default: You are in 'detached HEAD' state. You can look around, make experimental
    default: changes and commit them, and you can discard any commits you make in this
    default: state without impacting any branches by switching back to a branch.
    default: 
    default: If you want to create a new branch to retain commits you create, you may
    default: do so (now or later) by using -c with the switch command. Example:
    default: 
    default:   git switch -c <new-branch-name>
    default: 
    default: Or undo this operation with:
    default: 
    default:   git switch -
    default: 
    default: Turn off this advice by setting config variable advice.detachedHead to false
    default: 
    default: HEAD is now at df40a59 Merge pull request #267 from wazuh/enhancement/265-remove-last-stage-from-4.11.1-rc2
    default: Your branch is up to date with 'origin/main'.
    default: Using prod packages
    default: Configuring system
    default: Upgrading the system. This may take a while ...
    default: Last metadata expiration check: 0:00:09 ago on Wed Mar 26 14:04:12 2025.
    default: ================================================================================
    default: WARNING:
    default:   A newer release of "Amazon Linux" is available.
    default: 
    default:   Available Versions:
    default: 
    default:   Version 2023.6.20250211:
    default:     Run the following command to upgrade to 2023.6.20250211:
    default: 
    default:       dnf upgrade --releasever=2023.6.20250211
    default: 
    default:     Release notes:
    default:      https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes-2023.6.20250211.html
    default: 
    default:   Version 2023.6.20250218:
    default:     Run the following command to upgrade to 2023.6.20250218:
    default: 
    default:       dnf upgrade --releasever=2023.6.20250218
    default: 
    default:     Release notes:
    default:      https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes-2023.6.20250218.html
    default: 
    default:   Version 2023.6.20250303:
    default:     Run the following command to upgrade to 2023.6.20250303:
    default: 
    default:       dnf upgrade --releasever=2023.6.20250303
    default: 
    default:     Release notes:
    default:      https://docs.aws.amazon.com/linux/al2023/release-notes/relnotes-2023.6.20250303.html
    default: 
    default: ================================================================================
    default: Dependencies resolved.
    default: Nothing to do.
    default: Complete!
    default: Last metadata expiration check: 0:00:11 ago on Wed Mar 26 14:04:12 2025.
    default: Package dracut-102-3.amzn2023.0.1.x86_64 is already installed.
    default: Dependencies resolved.
    default: Nothing to do.
    default: Complete!
    default: dracut[E]: Module 'systemd-pcrphase' depends on 'tpm2-tss', which can't be installed
    default: grep: warning: stray \ before /
    default: grep: warning: stray \ before /
    default: grep: warning: stray \ before /
    default: Created symlink /etc/systemd/system/multi-user.target.wants/updateIndexerHeap.service → /etc/systemd/system/updateIndexerHeap.service.
    default: Editing installation script
    default: Installing Wazuh central components
    default: Unknow option: --install-dependencies
    default: 
    default: NAME
    default:         wazuh-install.sh - Install and configure Wazuh central components: Wazuh server, Wazuh indexer, and Wazuh dashboard.
    default: 
    default: SYNOPSIS
    default:         wazuh-install.sh [OPTIONS] -a | -c | -s | -wi <indexer-node-name> | -wd <dashboard-node-name> | -ws <server-node-name>
    default: 
    default: DESCRIPTION
    default:         -a,  --all-in-one
    default:                 Install and configure Wazuh server, Wazuh indexer, Wazuh dashboard.
    default: 
    default:         -c,  --config-file <path-to-config-yml>
    default:                 Path to the configuration file used to generate wazuh-install-files.tar file containing the files that will be needed for installation. By default, the Wazuh installation assistant will search for a file named config.yml in the same path as the script.
    default: 
    default:         -d [pre-release|staging],  --development
    default:                 Use development repositories. By default it uses the pre-release package repository. If staging is specified, it will use that repository.
    default: 
    default:         -dw,  --download-wazuh <deb|rpm>
    default:                 Download all the packages necessary for offline installation. Type of packages to download for offline installation (rpm, deb)
    default: 
    default:         -fd,  --force-install-dashboard
    default:                 Force Wazuh dashboard installation to continue even when it is not capable of connecting to the Wazuh indexer.
    default: 
    default:         -g,  --generate-config-files
    default:                 Generate wazuh-install-files.tar file containing the files that will be needed for installation from config.yml. In distributed deployments you will need to copy this file to all hosts.
    default: 
    default:         -h,  --help
    default:                 Display this help and exit.
    default: 
    default:         -i,  --ignore-check
    default:                 Ignore the check for minimum hardware requirements.
    default: 
    default:         -o,  --overwrite
    default:                 Overwrites previously installed components. This will erase all the existing configuration and data.
    default: 
    default:         -of,  --offline-installation
    default:                 Perform an offline installation. This option must be used with -a, -ws, -s, -wi, or -wd.
    default: 
    default:         -p,  --port
    default:                 Specifies the Wazuh web user interface port. By default is the 443 TCP port. Recommended ports are: 8443, 8444, 8080, 8888, 9000.
    default: 
    default:         -s,  --start-cluster
    default:                 Initialize Wazuh indexer cluster security settings.
    default: 
    default:         -t,  --tar <path-to-certs-tar>
    default:                 Path to tar file containing certificate files. By default, the Wazuh installation assistant will search for a file named wazuh-install-files.tar in the same path as the script.
    default: 
    default:         -u,  --uninstall
    default:                 Uninstalls all Wazuh components. This will erase all the existing configuration and data.
    default: 
    default:         -v,  --verbose
    default:                 Shows the complete installation output.
    default: 
    default:         -V,  --version
    default:                 Shows the version of the script and Wazuh packages.
    default: 
    default:         -wd,  --wazuh-dashboard <dashboard-node-name>
    default:                 Install and configure Wazuh dashboard, used for distributed deployments.
    default: 
    default:         -wi,  --wazuh-indexer <indexer-node-name>
    default:                 Install and configure Wazuh indexer, used for distributed deployments.
    default: 
    default:         -ws,  --wazuh-server <server-node-name>
    default:                 Install and configure Wazuh manager and Filebeat, used for distributed deployments.
    default: Traceback (most recent call last):
    default:   File "/tmp/workflow_assets/ova_configurer.py", line 163, in <module>
    default:     main()
    default:   File "/tmp/workflow_assets/ova_configurer.py", line 157, in main
    default:     run_provision_script(args.wvm_branch, args.repository, args.debug)
    default:   File "/tmp/workflow_assets/ova_configurer.py", line 59, in run_provision_script
    default:     subprocess.run(f"sudo bash provision.sh {repository} {debug}", shell=True, check=True)
    default:   File "/usr/lib64/python3.9/subprocess.py", line 528, in run
    default:     raise CalledProcessError(retcode, process.args,
    default: subprocess.CalledProcessError: Command 'sudo bash provision.sh prod no' returned non-zero exit status 1.
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
vagrant up failed, retrying in 10 seconds...
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
==> default: flag to force provisioning. Provisioners marked to run always will still run.
==> default: Attempting graceful shutdown of VM...
Exporting ova
0%...10%...20%...30%...40%...50%...60%...70%...80%...90%...100%
Successfully exported 1 machine(s).
==> default: Destroying VM and associated drives...
wazuh-4.11.1.ovf
wazuh-4.11.1-disk001.vmdk
Setting up ova for VMware ESXi
Standarizing OVA
Setting OVA to default
wazuh-4.11.1.ovf
wazuh-4.11.1-disk001.vmdk
OVF extracted
mv: '/tmp/test/wazuh-virtual-machines/ova/new-ova/wazuh-4.11.1.ovf' y '/tmp/test/wazuh-virtual-machines/ova/new-ova/wazuh-4.11.1.ovf' son el mismo fichero
Files renamed
OVF Version changed
OVF Size changed
Manifest changed
wazuh-4.11.1.ovf
wazuh-4.11.1-disk-1.vmdk
wazuh-4.11.1.mf
New OVA created
Cleaned temporary directory
Process finished
==> default: VM not created. Moving on...
$ 
```

</details>


<details><summary>Version 4.10.1:</summary>

```
$ git clone https://github.com/wazuh/wazuh-virtual-machines && cd wazuh-virtual-machines/ova/ && git checkout v4.10.1
Clonando en 'wazuh-virtual-machines'...
remote: Enumerating objects: 2220, done.
remote: Counting objects: 100% (141/141), done.
remote: Compressing objects: 100% (68/68), done.
remote: Total 2220 (delta 97), reused 94 (delta 71), pack-reused 2079 (from 3)
Recibiendo objetos: 100% (2220/2220), 673.54 KiB | 3.80 MiB/s, listo.
Resolviendo deltas: 100% (1020/1020), listo.
Nota: cambiando a 'v4.10.1'.

Te encuentras en estado 'detached HEAD'. Puedes revisar por aquí, hacer
cambios experimentales y hacer commits, y puedes descartar cualquier
commit que hayas hecho en este estado sin impactar a tu rama realizando
otro checkout.

Si quieres crear una nueva rama para mantener los commits que has creado,
puedes hacerlo (ahora o después) usando -c con el comando checkout. Ejemplo:

  git switch -c <nombre-de-nueva-rama>

O deshacer la operación con:

  git switch -

Desactiva este aviso poniendo la variable de config advice.detachedHead en false

HEAD está ahora en f9e1062 Merge pull request #141 from wazuh/enhancement/140-bump-new-version-4.10.1

$ ./generate_ova.sh 
Building Wazuh OVA version 4.10.1
Cloning Wazuh installation assistant repository
Using v4.10.1 branch of wazuh-installation-assistant repository
Building Wazuh installation assistant from v4.10.1 branch
Version to build: 4.10.1 with production repository
==> default: VM not created. Moving on...
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'amznlinux-2' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Box file was not detected as metadata. Adding it directly...
==> default: Adding box 'amznlinux-2' (v0) for provider: virtualbox
    default: Downloading: https://packages-dev.wazuh.com/vms/ova/amznlinux-2.box
Progress: 0% (Rate: 0*/s, Estimated time remaining: --:--:--)^C==> default: Waiting for cleanup before exiting...
==> default: Box download was interrupted. Exiting.
The box failed to unpackage properly. Please verify that the box
file you're trying to add is not corrupted and that enough disk space
is available and then try again.
The output from attempting to unpackage (if any):

bsdtar: Error opening archive: truncated gzip input

==> default: VM not created. Moving on...
$
```

</details>