### PR TITLE
Add AMI ref documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- (Add AMI ref documentation [#269](https://github.com/wazuh/wazuh-virtual-machines/pull/269))
 - Add AMI dev documentation ([#267](https://github.com/wazuh/wazuh-virtual-machines/pull/267))
 - Added AMI test framework ([#266](https://github.com/wazuh/wazuh-virtual-machines/pull/266))
 - Update the OVA creation workflow using the new python modules ([#262](https://github.com/wazuh/wazuh-virtual-machines/pull/262))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- (Add AMI ref documentation [#269](https://github.com/wazuh/wazuh-virtual-machines/pull/269))
+- Add AMI ref documentation ([#269](https://github.com/wazuh/wazuh-virtual-machines/pull/269))
 - Add AMI dev documentation ([#267](https://github.com/wazuh/wazuh-virtual-machines/pull/267))
 - Added AMI test framework ([#266](https://github.com/wazuh/wazuh-virtual-machines/pull/266))
 - Update the OVA creation workflow using the new python modules ([#262](https://github.com/wazuh/wazuh-virtual-machines/pull/262))

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -15,3 +15,9 @@
   - [Run Tests](dev/ova/ova-run-tests.md)
 
 # Reference Manual
+
+- [AMI Reference Manual](ref/ami/introduction.md)
+  - [Installation](ref/ami/installation.md)
+  - [Configuration](ref/ami/configuration.md)
+  - [Upgrade](ref/ami/upgrade.md)
+  - [Security](ref/ami/security.md)

--- a/docs/dev/ami/README.md
+++ b/docs/dev/ami/README.md
@@ -1,0 +1,8 @@
+# AMI Development
+
+This guide provides complete, step-by-step instructions for creating, configuring, testing, and generating both the AMI for Wazuh using an All-in-One environment.
+
+The guide is organized into the following sections:
+
+- **Generate Artifact**: Step-by-step guide for generating the AMI image in AWS. ([ami-generate-artifact.md](ami/ami-generate-artifact.md))
+- **Run Tests**: Procedure for executing tests to validate the AMI. ([ami-run-tests.md](ami/ami-run-tests.md))

--- a/docs/dev/ova/README.md
+++ b/docs/dev/ova/README.md
@@ -1,0 +1,1 @@
+# OVA Development

--- a/docs/ref/ami/configuration.md
+++ b/docs/ref/ami/configuration.md
@@ -1,0 +1,7 @@
+# Configurating the Wazuh Central Components in the AMI
+
+Any configuration you can apply to the Wazuh components included in the AMI is **identical to configuring them when installed separately**.
+
+This means that if you need to make adjustments or customizations, you can simply refer to the official documentation for each Wazuh component.
+
+> The AMI does not alter the standard behavior or configuration mechanisms of any Wazuh component.

--- a/docs/ref/ami/installation.md
+++ b/docs/ref/ami/installation.md
@@ -1,0 +1,41 @@
+# Installing the Wazuh AMI
+
+There are two alternatives for deploying a Wazuh instance. You can launch the Wazuh All-In-One Deployment AMI directly from the AWS Marketplace or you can configure and deploy an instance using the AWS Management Console.
+
+## Launching the Wazuh AMI from the AWS Marketplace
+
+1. Go to [Wazuh All-In-One Deployment](https://aws.amazon.com/marketplace/pp/prodview-eju4flv5eqmgq?ref=hmpg_recommendations_widget) in the AWS Marketplace, then click **Continue to Subscribe**.
+2. Review the information and accept the terms for the software. Click **Continue to Configuration** to confirm subscribing to our Server product.
+3. Select a **Software Version** and the **Region** where the instance is going to be deployed. Then, click **Continue to Launch**.
+4. Review your configuration, making sure that all settings are correct before launching the software. Adapt the default configuration values to your needs.
+    1. **Instance Type**: When selecting the EC2 Instance Type, we recommend that you use an instance type `c5a.xlarge`.
+    2. **Network Settings**: When selecting the **Security Group**, it must be one with the appropriate settings for your Wazuh instance to guarantee the correct operation. You can create a new security group by choosing **Create new based on seller** settings. This new group will have the appropriate settings by default.
+5. Click **Launch** to start the instance.
+
+Once your instance is successfully launched and a few minutes have elapsed, you can access the Wazuh dashboard.
+
+## Deploy an instance using the AWS Management Console
+
+1. Select **Launch instance** from your AWS Management Console dashboard.
+
+2. Find **Wazuh All-In-One Deployment by Wazuh Inc.**, and click **Select** to subscribe.
+
+3. Review the Server product characteristics, then click **Continue**. This allows subscribing to our Server product.
+
+4. Select the instance type according to your needs, then click Next: Configure Instance Details. We recommend that you use an instance type `c5a.xlarge`.
+
+5. Configure your instance as needed, then click Next: **Add Storage**.
+
+6. Set the storage capacity of your instance under the **Size (GiB)** column, then click Next: **Add Tags**. We recommend 100 GiB GP3 or more.
+
+7. Add as many tags as you need, then click Next: **Configure Security Group**.
+
+8. Check that the ports and protocols are the ports and protocols for Wazuh. Check the security measures for your instance. This will establish the Security Group (SG). Then, click **Review and Launch**.
+
+9. Review the instance configuration and click **Launch**.
+
+10. Select one of three configuration alternatives available regarding the key pair settings: **Choose an existing key pair**, **Create a new key pair**, Proceed without a key pair. You need to choose an existing key pair or create a new one to access the instance with SSH.
+
+11. Click **Launch instances** to complete the process and deploy your instance.
+
+Once your instance is fully configured and ready after a few minutes since launch, you can access the Wazuh dashboard.

--- a/docs/ref/ami/introduction.md
+++ b/docs/ref/ami/introduction.md
@@ -1,0 +1,19 @@
+# Introduction to Wazuh AMI
+
+Wazuh provides a pre-built **Amazon Machine Image (AMI)**. An AMI is a ready-to-use template for creating virtual computing environments in **Amazon Elastic Compute Cloud (Amazon EC2)**.
+
+The latest Wazuh AMI includes the Wazuh central components:
+
+- Wazuh Server  
+- Wazuh Indexer  
+- Wazuh Dashboard
+
+It is designed to be deployed in an **All-in-One** configuration, which means that all components are installed on a single instance.
+
+> This AMI does not include the Wazuh agent. If you need to deploy Wazuh agents, you can do so separately on your desired hosts.
+
+## Compatibility
+
+- **Operating System**: Amazon Linux 2023  
+- **Architecture**: 64-bit  
+- **VM Format**: AWS AMI

--- a/docs/ref/ami/security.md
+++ b/docs/ref/ami/security.md
@@ -1,0 +1,15 @@
+# Security
+
+## Security considerations about SSH
+
+- The `root` user cannot be identified by SSH and the instance can only be accessed through the `wazuh-user` user.
+- SSH authentication through passwords is disabled and the instance can only be accessed through a key pair. This means that only the user with the key pair has access to the instance.
+- To access the instance with a key pair, you need to download the key generated or stored in AWS. Then, run the following command to connect with the instance.
+
+    ```bash
+    ssh -i "<KEY_PAIR_NAME>" wazuh-user@<YOUR_INSTANCE_IP>
+    ```
+
+## Access the Wazuh dashboard
+
+> 🚧 Details on how to access to the Wazuh Dashboard UI will be provided later.

--- a/docs/ref/ami/upgrade.md
+++ b/docs/ref/ami/upgrade.md
@@ -1,0 +1,7 @@
+# Upgrading the Wazuh Central Components in the AMI
+
+Upgrading the Wazuh components included in the AMI follows the **same procedure as when upgrading them individually**.
+
+If you need to update any component (Wazuh Server, Wazuh Indexer, or Wazuh Dashboard), you can follow the official upgrade guides provided by Wazuh.
+
+> The AMI does not modify the standard upgrade process of any Wazuh component, so the official documentation remains fully applicable.


### PR DESCRIPTION
# Description

The purpose of this PR is to add the AMI documentation related to the reference manual.  
In addition, the README files for the AMI and OVA in the development section have also been added.

> [!Note] 
> The part explaining how to access the dashboard UI is still pending since the section for changing the components' passwords has not yet been completed.
