### PR TITLE
Fixed several OVA workflow and creation process errors

### DIFF
--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -212,7 +212,7 @@ jobs:
           scp -P ${{ env.INSTANCE_PORT }} \
               -i ${{ env.INSTANCE_KEY }} \
               "${{ env.LOCAL_ARTIFACTS_URLS_FILEPATH }}" \
-              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:/tmp/${{ env.WVM_REPO_NAME }}
+              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:~/${{ env.WVM_REPO_NAME }}
 
       - name: Run the OVA PreConfigurer module
         run: |

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -256,6 +256,7 @@ jobs:
           scp -P ${{ env.INSTANCE_PORT }} \
               -i ${{ env.INSTANCE_KEY }} \
               ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:~/${{ env.WVM_REPO_NAME }}/${{ env.FILENAME_OVA }} /tmp/${{ env.FILENAME_OVA }}
+          sudo chmod 0777 /tmp/${{ env.FILENAME_OVA }}
 
       - name: Standarizing OVA
         run: |

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -199,13 +199,11 @@ jobs:
 
       - name: Clone repo on remote instance
         run: |
-          ssh -p ${{ env.INSTANCE_PORT }} \
+          scp -r -P ${{ env.INSTANCE_PORT }} \
               -i ${{ env.INSTANCE_KEY }} \
               -o 'StrictHostKeyChecking no' \
-              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }} << EOF
-            set -e
-            git clone ${{ env.WVM_REPOSITORY_PATH }}
-          EOF
+              "${{ github.workspace }}/wazuh-virtual-machines" \
+              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:/tmp/
 
       - name: Copy artifacts URLs file to remote instance
         run: |

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -255,24 +255,24 @@ jobs:
         run: |
           scp -P ${{ env.INSTANCE_PORT }} \
               -i ${{ env.INSTANCE_KEY }} \
-              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:~/${{ env.WVM_REPO_NAME }}/${{ env.FILENAME_OVA }} /tmp/${{ env.FILENAME_OVA }}
+              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:~/${{ env.WVM_REPO_NAME }}/${{ env.FILENAME_OVA }} ${{ github.workspace }}/${{ env.FILENAME_OVA }}
 
       - name: Standarizing OVA
         run: |
           sudo chmod 0777 ${{ env.OVA_SCRIPTS_PATH }}/${{ env.OVA_SET_DEFAULT_SCRIPT_NAME }}
           sed -i "s|ovf:capacity=\"40\"|ovf:capacity=\"50\"|g" ${{ env.OVA_SCRIPTS_PATH }}/${{ env.OVA_OVF_TEMPLATE_NAME }}
-          sudo bash ${{ env.OVA_SCRIPTS_PATH }}/${{ env.OVA_SET_DEFAULT_SCRIPT_NAME }} "${{ env.OVA_SCRIPTS_PATH }}/" "/tmp/${{ env.FILENAME_OVA }}" "/tmp/${{ env.FILENAME_OVA }}" ${{ env.OVA_SCRIPTS_PATH }}/${{ env.OVA_OVF_TEMPLATE_NAME }} "${{ env.WAZUH_VERSION }}"
+          sudo bash ${{ env.OVA_SCRIPTS_PATH }}/${{ env.OVA_SET_DEFAULT_SCRIPT_NAME }} "${{ env.OVA_SCRIPTS_PATH }}/" "${{ github.workspace }}/${{ env.FILENAME_OVA }}" "${{ github.workspace }}/${{ env.FILENAME_OVA }}" ${{ env.OVA_SCRIPTS_PATH }}/${{ env.OVA_OVF_TEMPLATE_NAME }} "${{ env.WAZUH_VERSION }}"
 
       - name: Exporting OVA to final repository
         run: |
-          aws s3 cp --quiet /tmp/${{ env.FILENAME_OVA }} s3://${{ env.S3_BUCKET_TO_STORE_OVA }}/${{ env.S3_PATH_TO_STORE_OVA }}/${{ env.FILENAME_OVA }}
+          aws s3 cp --quiet ${{ github.workspace }}/${{ env.FILENAME_OVA }} s3://${{ env.S3_BUCKET_TO_STORE_OVA }}/${{ env.S3_PATH_TO_STORE_OVA }}/${{ env.FILENAME_OVA }}
           s3uri="s3://${{ env.S3_BUCKET_TO_STORE_OVA }}/${{ env.S3_PATH_TO_STORE_OVA }}/${{ env.FILENAME_OVA }}"
           echo "S3 OVA URI: ${s3uri}"
   
       - name: Generating sha512 file
         if: ${{ inputs.checksum == true }}
         run: |
-          sha512sum /tmp/${{ env.FILENAME_OVA }} > /tmp/${{ env.FILENAME_SHA }}
+          sha512sum ${{ github.workspace }}/${{ env.FILENAME_OVA }} > ${{ github.workspace }}/${{ env.FILENAME_SHA }}
           aws s3 cp --quiet /tmp/${{ env.FILENAME_SHA }} s3://${{ env.S3_BUCKET_TO_STORE_OVA }}/${{ env.S3_PATH_TO_STORE_OVA }}/${{ env.FILENAME_SHA }}
           s3uri="s3://${{ env.S3_BUCKET_TO_STORE_OVA }}/${{ env.S3_PATH_TO_STORE_OVA }}/${{ env.FILENAME_SHA }}"
           echo "S3 sha512 OVA URI: ${s3uri}"

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -199,18 +199,20 @@ jobs:
 
       - name: Clone repo on remote instance
         run: |
-          scp -r -P ${{ env.INSTANCE_PORT }} \
+          ssh -p ${{ env.INSTANCE_PORT }} \
               -i ${{ env.INSTANCE_KEY }} \
               -o 'StrictHostKeyChecking no' \
-              "${{ github.workspace }}" \
-              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:/tmp/wazuh-virtual-machines
+              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }} << EOF
+            set -e
+            git clone -b ${{ inputs.wazuh_virtual_machines_reference }} ${{ env.WVM_REPOSITORY_PATH }}
+          EOF
 
       - name: Copy artifacts URLs file to remote instance
         run: |
           scp -P ${{ env.INSTANCE_PORT }} \
               -i ${{ env.INSTANCE_KEY }} \
               "${{ env.LOCAL_ARTIFACTS_URLS_FILEPATH }}" \
-              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:~/${{ env.WVM_REPO_NAME }}
+              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:/tmp/${{ env.WVM_REPO_NAME }}
 
       - name: Run the OVA PreConfigurer module
         run: |

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -202,8 +202,8 @@ jobs:
           scp -r -P ${{ env.INSTANCE_PORT }} \
               -i ${{ env.INSTANCE_KEY }} \
               -o 'StrictHostKeyChecking no' \
-              "${{ github.workspace }}/wazuh-virtual-machines" \
-              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:/tmp/
+              "${{ github.workspace }}" \
+              ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:/tmp/wazuh-virtual-machines
 
       - name: Copy artifacts URLs file to remote instance
         run: |

--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -256,10 +256,10 @@ jobs:
           scp -P ${{ env.INSTANCE_PORT }} \
               -i ${{ env.INSTANCE_KEY }} \
               ${{ env.INSTANCE_USER }}@${{ env.INSTANCE_HOSTNAME }}:~/${{ env.WVM_REPO_NAME }}/${{ env.FILENAME_OVA }} /tmp/${{ env.FILENAME_OVA }}
-          sudo chmod 0777 /tmp/${{ env.FILENAME_OVA }}
 
       - name: Standarizing OVA
         run: |
+          sudo chmod 0777 ${{ env.OVA_SCRIPTS_PATH }}/${{ env.OVA_SET_DEFAULT_SCRIPT_NAME }}
           sed -i "s|ovf:capacity=\"40\"|ovf:capacity=\"50\"|g" ${{ env.OVA_SCRIPTS_PATH }}/${{ env.OVA_OVF_TEMPLATE_NAME }}
           sudo bash ${{ env.OVA_SCRIPTS_PATH }}/${{ env.OVA_SET_DEFAULT_SCRIPT_NAME }} "${{ env.OVA_SCRIPTS_PATH }}/" "/tmp/${{ env.FILENAME_OVA }}" "/tmp/${{ env.FILENAME_OVA }}" ${{ env.OVA_SCRIPTS_PATH }}/${{ env.OVA_OVF_TEMPLATE_NAME }} "${{ env.WAZUH_VERSION }}"
 

--- a/configurer/ova/ova_post_configurer/ova_post_configurer.py
+++ b/configurer/ova/ova_post_configurer/ova_post_configurer.py
@@ -353,8 +353,7 @@ def main() -> None:
     for index in indexes:
         run_command(f"curl -u admin:admin -XDELETE 'https://127.0.0.1:9200/{index}' -k")
 
-    std_out, _,_ = run_command("bash /usr/share/wazuh-indexer/bin/indexer-security-init.sh -ho 127.0.0.1", output=True)
-    logger.debug(std_out)
+    run_command("bash /usr/share/wazuh-indexer/bin/indexer-security-init.sh -ho 127.0.0.1")
 
     commands = [
         "systemctl stop wazuh-indexer wazuh-dashboard",

--- a/configurer/ova/ova_post_configurer/ova_post_configurer.py
+++ b/configurer/ova/ova_post_configurer/ova_post_configurer.py
@@ -353,7 +353,8 @@ def main() -> None:
     for index in indexes:
         run_command(f"curl -u admin:admin -XDELETE 'https://127.0.0.1:9200/{index}' -k")
 
-    run_command("bash /usr/share/wazuh-indexer/bin/indexer-security-init.sh -ho 127.0.0.1")
+    std_out, _,_ = run_command("bash /usr/share/wazuh-indexer/bin/indexer-security-init.sh -ho 127.0.0.1", output=True)
+    logger.debug(std_out)
 
     commands = [
         "systemctl stop wazuh-indexer wazuh-dashboard",

--- a/configurer/ova/ova_post_configurer/scripts/wazuh-starter/wazuh-starter.sh
+++ b/configurer/ova/ova_post_configurer/scripts/wazuh-starter/wazuh-starter.sh
@@ -78,6 +78,13 @@ function verify_dashboard() {
   done
 }
 
+function remove_kibana_index() {
+  logger "Removing Kibana index"
+  curl -XDELETE -k -u admin:admin https://127.0.0.1:9200/.kibana*
+  logger "Restarting Wazuh Dashboard"
+  systemctl restart wazuh-dashboard
+}
+
 function clean_configuration(){
   logger "Cleaning configuration files"
   eval "rm -rf /var/log/wazuh-starter.log"
@@ -98,6 +105,7 @@ verify_indexer
 starter_service wazuh-server
 
 starter_service wazuh-dashboard
+remove_kibana_index
 verify_dashboard
 systemctl enable wazuh-server
 systemctl enable wazuh-dashboard

--- a/configurer/ova/ova_post_configurer/scripts/wazuh-starter/wazuh-starter.sh
+++ b/configurer/ova/ova_post_configurer/scripts/wazuh-starter/wazuh-starter.sh
@@ -95,11 +95,11 @@ logger "Starting Wazuh services in order"
 starter_service wazuh-indexer
 verify_indexer
 
-starter_service wazuh-manager
+starter_service wazuh-server
 
 starter_service wazuh-dashboard
 verify_dashboard
-systemctl enable wazuh-manager
+systemctl enable wazuh-server
 systemctl enable wazuh-dashboard
 
 clean_configuration

--- a/configurer/ova/ova_pre_configurer/install_dependencies.py
+++ b/configurer/ova/ova_pre_configurer/install_dependencies.py
@@ -175,7 +175,6 @@ def install_vagrant() -> None:
         "sudo yum install -y yum-utils shadow-utils",
         f"sudo yum-config-manager --add-repo {VAGRANT_REPO_URL}",
         "sudo yum -y install vagrant",
-        "vagrant plugin install vagrant-scp",
     ]
     run_command(commands)
 

--- a/configurer/ova/ova_pre_configurer/ova_pre_configurer.py
+++ b/configurer/ova/ova_pre_configurer/ova_pre_configurer.py
@@ -100,7 +100,11 @@ def prepare_vm() -> None:
             os.remove(filename)
 
     logger.debug("Copying the wazuh-virtual-machines repository to the VM.")
-    run_command("vagrant scp ../wazuh-virtual-machines :/tmp/wazuh-virtual-machines")
+    commands = [
+        "vagrant ssh-config > ssh-config",
+        "scp -r -F ssh-config ../wazuh-virtual-machines default:/tmp/wazuh-virtual-machines",
+    ]
+    run_command(commands, check=True)
 
 
 def main() -> None:

--- a/tests/test_configurer/test_ova/test_ova_pre_configurer/test_install_dependencies.py
+++ b/tests/test_configurer/test_ova/test_ova_pre_configurer/test_install_dependencies.py
@@ -140,7 +140,6 @@ def test_install_vagrant_success(mock_run_command, mock_logger):
         "sudo yum install -y yum-utils shadow-utils",
         f"sudo yum-config-manager --add-repo {VAGRANT_REPO_URL}",
         "sudo yum -y install vagrant",
-        "vagrant plugin install vagrant-scp",
     ]
     mock_run_command.assert_called_once_with(commands)
 

--- a/tests/test_configurer/test_ova/test_ova_pre_configurer/test_ova_pre_configurer.py
+++ b/tests/test_configurer/test_ova/test_ova_pre_configurer/test_ova_pre_configurer.py
@@ -105,10 +105,11 @@ def test_deploy_vm_custom_path(mock_add_vagrant_box, mock_run_vagrant_up, mock_l
     mock_run_vagrant_up.assert_called_once()
 
 
+@patch("configurer.ova.ova_pre_configurer.ova_pre_configurer.prepare_vm")
 @patch("configurer.ova.ova_pre_configurer.ova_pre_configurer.deploy_vm")
 @patch("configurer.ova.ova_pre_configurer.ova_pre_configurer.generate_base_box_main")
 @patch("configurer.ova.ova_pre_configurer.ova_pre_configurer.install_dependencies_main")
-def test_main(mock_install_dependencies, mock_generate_base_box, mock_deploy_vm, mock_logger):
+def test_main(mock_install_dependencies, mock_generate_base_box, mock_deploy_vm, mock_prepare_vm, mock_logger):
     main()
 
     mock_logger.info.assert_any_call("--- Starting OVA PreConfigurer ---")
@@ -119,4 +120,5 @@ def test_main(mock_install_dependencies, mock_generate_base_box, mock_deploy_vm,
     mock_generate_base_box.assert_called_once()
 
     mock_deploy_vm.assert_called_once()
+    mock_prepare_vm.assert_called_once()
     mock_logger.info_success.assert_called_once_with("OVA PreConfigurer completed.")


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-virtual-machines/issues/268

# Description

The first goal of this PR was to fix the bug that was being caused by the `vagrant-scp` plugin. This bug was fixed by changing and dropping this plugin and copying the repository directly with `scp` using the `ssh-config`.

But in addition, during the development of this fix, some more bugs were observed both in the workflow and in the final product that have been corrected:

### 1. Cloning of the `wazuh-virtual-machines` repository with the desired branch

The `wazuh-virtual-machines` repository was being copied with the default `main` branch, `git clone -b <branch>` was added to clone the repository to the branch entered as input in the workflow.

### 2. Error running `setOVADefault.sh` script

Running the `setOVADefault.sh` script in the workflow was giving `Permission denied` error. This caused the final OVA product to not have the correct name and descriptions corresponding to Wazuh. This error has been fixed by changing where the OVA is saved in the workflow runner.

### 3. Error starting `wazuh-server` service

To start Wazuh services, we have a script that runs at machine startup. Fixed the bug that left the old name `wazuh-manager` and changed it to `wazuh-server`.

### 4. Wazuh Dashboard error when creating the index

When starting the machine, the web access to the Dashboard was not working. This was because an attempt was being made to create a `kibana` index that already existed. To solve this error, the Dashboard team was consulted and the solution was to delete the problematic index and restart the Wazuh Dashboard service. This change has been included in the `wazuh-starter.sh` which is the aforementioned service that is responsible for raising the Wazuh services.

> [!NOTE]  
> The development of these changes can be consulted in the related issue.

## Tests

A complete test of the OVA creation process has been made. The creation can be seen in this workflow run: https://github.com/wazuh/wazuh-virtual-machines/actions/runs/14643702961/job/41092261929


In addition, it has been verified that all Wazuh services are up when importing the OVA and that Dashboard can be accessed via web browser.

<details>
<summary>Check that all Wazuh services are running:</summary>

```shellsession
(base) ➜  /tmp ssh wazuh-user@192.168.1.218
The authenticity of host '192.168.1.218 (192.168.1.218)' can't be established.
ECDSA key fingerprint is SHA256:K029KvcKtf6MgQ23dgE5u/L68xNWU5lbzZCxHuSZkeo.
This key is not known by any other names.
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '192.168.1.218' (ECDSA) to the list of known hosts.
wazuh-user@192.168.1.218's password: 
wwwwww.           wwwwwww.          wwwwwww.
wwwwwww.          wwwwwww.          wwwwwww.
 wwwwww.         wwwwwwwww.        wwwwwww.
 wwwwwww.        wwwwwwwww.        wwwwwww.
  wwwwww.       wwwwwwwwwww.      wwwwwww.
  wwwwwww.      wwwwwwwwwww.      wwwwwww.
   wwwwww.     wwwwww.wwwwww.    wwwwwww.
   wwwwwww.    wwwww. wwwwww.    wwwwwww.
    wwwwww.   wwwwww.  wwwwww.  wwwwwww.
    wwwwwww.  wwwww.   wwwwww.  wwwwwww.
     wwwwww. wwwwww.    wwwwww.wwwwwww.
     wwwwwww.wwwww.     wwwwww.wwwwwww.
      wwwwwwwwwwww.      wwwwwwwwwwww.
      wwwwwwwwwww.       wwwwwwwwwwww.      oooooo
       wwwwwwwwww.        wwwwwwwwww.      oooooooo
       wwwwwwwww.         wwwwwwwwww.     oooooooooo
        wwwwwwww.          wwwwwwww.      oooooooooo
        wwwwwww.           wwwwwwww.       oooooooo
         wwwwww.            wwwwww.         oooooo


         WAZUH Open Source Security Platform
                  https://wazuh.com
Last login: Thu Apr 24 15:04:38 2025

[root@wazuh-server wazuh-user]# systemctl status wazuh-indexer
● wazuh-indexer.service - wazuh-indexer
     Loaded: loaded (/usr/lib/systemd/system/wazuh-indexer.service; enabled; preset: disabled)
     Active: active (running) since Thu 2025-04-24 15:04:43 UTC; 3min 57s ago
       Docs: https://documentation.wazuh.com
   Main PID: 2377 (java)
      Tasks: 106 (limit: 9469)
     Memory: 4.5G
        CPU: 45.472s
     CGroup: /system.slice/wazuh-indexer.service
             └─2377 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=tr>

Apr 24 15:04:34 wazuh-server systemd-entrypoint[2377]: WARNING: A terminally deprecated method in java.lang.System has been called
Apr 24 15:04:34 wazuh-server systemd-entrypoint[2377]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.OpenSearch (file:/usr/share/wazuh-indexer/lib/opensearch-2.19.1.jar)
Apr 24 15:04:34 wazuh-server systemd-entrypoint[2377]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.OpenSearch
Apr 24 15:04:34 wazuh-server systemd-entrypoint[2377]: WARNING: System::setSecurityManager will be removed in a future release
Apr 24 15:04:34 wazuh-server systemd-entrypoint[2377]: Apr 24, 2025 3:04:34 PM sun.util.locale.provider.LocaleProviderAdapter <clinit>
Apr 24 15:04:34 wazuh-server systemd-entrypoint[2377]: WARNING: COMPAT locale provider will be removed in a future release
Apr 24 15:04:34 wazuh-server systemd-entrypoint[2377]: WARNING: A terminally deprecated method in java.lang.System has been called
Apr 24 15:04:34 wazuh-server systemd-entrypoint[2377]: WARNING: System::setSecurityManager has been called by org.opensearch.bootstrap.Security (file:/usr/share/wazuh-indexer/lib/opensearch-2.19.1.jar)
Apr 24 15:04:34 wazuh-server systemd-entrypoint[2377]: WARNING: Please consider reporting this to the maintainers of org.opensearch.bootstrap.Security
Apr 24 15:04:34 wazuh-server systemd-entrypoint[2377]: WARNING: System::setSecurityManager will be removed in a future release
[root@wazuh-server wazuh-user]# systemctl status wazuh-server
● wazuh-server.service - Wazuh server
     Loaded: loaded (/usr/lib/systemd/system/wazuh-server.service; enabled; preset: disabled)
     Active: active (running) since Thu 2025-04-24 15:04:49 UTC; 3min 56s ago
   Main PID: 2747 (sh)
      Tasks: 82 (limit: 9469)
     Memory: 420.8M
        CPU: 10.379s
     CGroup: /system.slice/wazuh-server.service
             ├─2747 /usr/bin/sh -c "/usr/share/wazuh-server/bin/wazuh-server start 2>&1 | tee -a /var/log/wazuh-server/wazuh-server.log"
             ├─2749 /bin/sh /usr/share/wazuh-server/bin/wazuh-server start
             ├─2750 tee -a /var/log/wazuh-server/wazuh-server.log
             ├─2755 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/framework/scripts/wazuh-server.py start
             ├─2818 /usr/share/wazuh-server/bin/wazuh-engine server -l info start
             ├─3288 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
             ├─3293 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
             ├─3310 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
             ├─3311 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
             ├─3314 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
             ├─3328 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
             ├─3329 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
             ├─3330 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
             ├─3331 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-comms-apid.py
             ├─3334 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py
             ├─3341 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py
             ├─3344 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py
             ├─3347 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py
             └─3355 /usr/share/wazuh-server/framework/python/bin/python3 /usr/share/wazuh-server/apis/scripts/wazuh-server-management-apid.py

Apr 24 15:07:10 wazuh-server sh[2750]: 2025/04/24 15:07:10 INFO: [Server] [Main] Getting orders from indexer
Apr 24 15:07:20 wazuh-server sh[2750]: 2025/04/24 15:07:20 INFO: [Server] [Main] Getting orders from indexer
Apr 24 15:07:30 wazuh-server sh[2750]: 2025/04/24 15:07:30 INFO: [Server] [Main] Getting orders from indexer
Apr 24 15:07:40 wazuh-server sh[2750]: 2025/04/24 15:07:40 INFO: [Server] [Main] Getting orders from indexer
Apr 24 15:07:50 wazuh-server sh[2750]: 2025/04/24 15:07:50 INFO: [Server] [Main] Getting orders from indexer
Apr 24 15:08:00 wazuh-server sh[2750]: 2025/04/24 15:08:00 INFO: [Server] [Main] Getting orders from indexer
Apr 24 15:08:10 wazuh-server sh[2750]: 2025/04/24 15:08:10 INFO: [Server] [Main] Getting orders from indexer
Apr 24 15:08:20 wazuh-server sh[2750]: 2025/04/24 15:08:20 INFO: [Server] [Main] Getting orders from indexer
Apr 24 15:08:30 wazuh-server sh[2750]: 2025/04/24 15:08:30 INFO: [Server] [Main] Getting orders from indexer
Apr 24 15:08:40 wazuh-server sh[2750]: 2025/04/24 15:08:40 INFO: [Server] [Main] Getting orders from indexer
[root@wazuh-server wazuh-user]# systemctl status wazuh-dashboard
● wazuh-dashboard.service - wazuh-dashboard
     Loaded: loaded (/etc/systemd/system/wazuh-dashboard.service; enabled; preset: disabled)
     Active: active (running) since Thu 2025-04-24 15:04:50 UTC; 3min 58s ago
   Main PID: 2789 (node)
      Tasks: 11 (limit: 9469)
     Memory: 217.1M
        CPU: 5.336s
     CGroup: /system.slice/wazuh-dashboard.service
             └─2789 /usr/share/wazuh-dashboard/node/bin/node --no-warnings --max-http-header-size=65536 --unhandled-rejections=warn /usr/share/wazuh-dashboard/src/cli/dist

Apr 24 15:04:57 wazuh-server opensearch-dashboards[2789]: {"type":"log","@timestamp":"2025-04-24T15:04:57Z","tags":["info","plugins","wazuhCore","initialization","index-pattern:states-inventory-processes"],"pid">
Apr 24 15:04:57 wazuh-server opensearch-dashboards[2789]: {"type":"log","@timestamp":"2025-04-24T15:04:57Z","tags":["info","plugins","wazuhCore","initialization","index-pattern:commands"],"pid":2789,"message":"C>
Apr 24 15:04:57 wazuh-server opensearch-dashboards[2789]: {"type":"log","@timestamp":"2025-04-24T15:04:57Z","tags":["info","plugins","wazuhCore","initialization","index-pattern:states-fim"],"pid":2789,"message":>
Apr 24 15:04:57 wazuh-server opensearch-dashboards[2789]: {"type":"log","@timestamp":"2025-04-24T15:04:57Z","tags":["info","plugins","wazuhCore","initialization","index-pattern:states-vulnerabilities"],"pid":278>
Apr 24 15:04:57 wazuh-server opensearch-dashboards[2789]: {"type":"log","@timestamp":"2025-04-24T15:04:57Z","tags":["info","plugins","wazuhCore","initialization","index-pattern:states-system"],"pid":2789,"messag>
Apr 24 15:04:57 wazuh-server opensearch-dashboards[2789]: {"type":"log","@timestamp":"2025-04-24T15:04:57Z","tags":["info","plugins","wazuhCore","initialization","index-pattern:alerts"],"pid":2789,"message":"Cre>
Apr 24 15:04:57 wazuh-server opensearch-dashboards[2789]: {"type":"log","@timestamp":"2025-04-24T15:04:57Z","tags":["listening","info"],"pid":2789,"message":"Server running at https://0.0.0.0:443"}
Apr 24 15:04:59 wazuh-server opensearch-dashboards[2789]: {"type":"log","@timestamp":"2025-04-24T15:04:59Z","tags":["info","http","server","OpenSearchDashboards"],"pid":2789,"message":"http server running at htt>
Apr 24 15:05:07 wazuh-server opensearch-dashboards[2789]: [agentkeepalive:deprecated] options.freeSocketKeepAliveTimeout is deprecated, please use options.freeSocketTimeout instead
Apr 24 15:05:07 wazuh-server opensearch-dashboards[2789]: {"type":"response","@timestamp":"2025-04-24T15:05:07Z","tags":[],"pid":2789,"method":"get","statusCode":200,"req":{"url":"/status","method":"get","header>
[root@wazuh-server wazuh-user]#
```

</details>

#### Wazuh Dashboard web interface

![Captura desde 2025-04-24 17-09-45](https://github.com/user-attachments/assets/f55cb313-4ec6-40ab-bee5-decd737e512d)
