### PR TITLE
Add wget as a package dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add wget as a package dependency ([#309](https://github.com/wazuh/wazuh-virtual-machines/pull/309))
 - Create build process for local ova and fix certificates default path for Wazuh Server ([#299](https://github.com/wazuh/wazuh-virtual-machines/pull/299))
 - Added OVA test to VM framework test module ([#276](https://github.com/wazuh/wazuh-virtual-machines/pull/276))
 - Add OVA documentation ([#275](https://github.com/wazuh/wazuh-virtual-machines/pull/275))

--- a/configurer/ova/ova_pre_configurer/install_dependencies.py
+++ b/configurer/ova/ova_pre_configurer/install_dependencies.py
@@ -19,6 +19,7 @@ REQUIRED_PACKAGES = [
     "perl",
     "python3-pip",
     "git",
+    "wget",
 ]
 VAGRANT_REPO_URL = "https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo"
 

--- a/configurer/ova/ova_pre_configurer/static/Vagrantfile
+++ b/configurer/ova/ova_pre_configurer/static/Vagrantfile
@@ -14,6 +14,7 @@ Vagrant.configure("2") do |config|
   
     # Create a private network, which allows host-only access to the machine
     # using a specific IP.
+    config.vm.network "private_network", ip: "192.168.56.22", interface: "2"
     config.vm.hostname = "wazuh-server"
   
     # Example for VirtualBox:

--- a/configurer/ova/ova_pre_configurer/static/Vagrantfile
+++ b/configurer/ova/ova_pre_configurer/static/Vagrantfile
@@ -14,7 +14,6 @@ Vagrant.configure("2") do |config|
   
     # Create a private network, which allows host-only access to the machine
     # using a specific IP.
-    config.vm.network "private_network", ip: "192.168.56.22", interface: "2"
     config.vm.hostname = "wazuh-server"
   
     # Example for VirtualBox:


### PR DESCRIPTION
# Description

One of the required dependencies to generate the Wazuh OVA is `wget`. If this dependency is not installed when building the OVA, the process will fail.

To prevent this, wget has been added to the list of packages installed during the OVA's pre-configuration step. This ensures it is always present on the system before the creation process begins.

## Testing 🧪 

We can see in this workflow that wget is installed during the dependency installation step:
- https://github.com/wazuh/wazuh-virtual-machines/actions/runs/15205626392
```
2025-05-23 08:16:41 [ INFO  ] Configurer helpers: Executing: sudo yum install -y kernel-devel-6.1.134-152.225.amzn2023.x86_64 kernel-headers-6.1.134-152.225.amzn2023.x86_64 dkms elfutils-libelf-devel gcc make perl python3-pip git wget
```

>[!important]
> The workflow fails because the indexer packages are missing from the bucket where all the packages are stored. Therefore, it is not an issue inherent to the OVA itself.