### PR TITLE
Fix deprecated Ansible YAML callback plugin in OVA build workflow

### DIFF
--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -70,7 +70,6 @@ env:
     WIA_DIR: "wazuh-installation-assistant"
     WIA_REPOSITORY: "https://github.com/wazuh/wazuh-installation-assistant"
     WVM_REPOSITORY: "https://github.com/wazuh/wazuh-virtual-machines"
-    ANSIBLE_CALLBACK: "yaml"
 
 permissions:
   id-token: write   # This is required for requesting the JWT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix deprecated Ansible YAML callback plugin in OVA build workflow ([#463](https://github.com/wazuh/wazuh-virtual-machines/pull/463))
 - Fix vagrant up inconsistencies at the start. ([#434](https://github.com/wazuh/wazuh-virtual-machines/pull/434))
 
 ### Deleted


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-virtual-machines/issues/462

# Description

The aim of this PR is to fix the deprecated Ansible YAML callback in the OVA build workflow.

## Tests

### Workflow execution

The workflow execution is here: https://github.com/wazuh/wazuh-virtual-machines/actions/runs/19233070430/job/54975966681

### OVA import

<img width="806" height="693" alt="imagen" src="https://github.com/user-attachments/assets/3aaf6bb7-4027-46fc-8d55-bbad4f1e78f9" />

<img width="912" height="702" alt="imagen" src="https://github.com/user-attachments/assets/df66bb47-c1de-4bf9-9e29-eea01b491880" />

<img width="2558" height="1258" alt="imagen" src="https://github.com/user-attachments/assets/f2f00101-0b34-45f2-8dac-9cc61144c555" />
