### PR TITLE
Changed OVA and AMI deployment requirements and documentation

### DIFF
--- a/.github/workflows/test-vm.yaml
+++ b/.github/workflows/test-vm.yaml
@@ -34,10 +34,10 @@ on:
       instance_type:
         description: 'EC2 instance type for AMI tests'
         required: false
-        default: 'c5ad.xlarge'
+        default: 'c5ad.2xlarge'
         type: choice
         options:
-          - c5ad.xlarge
+          - c5ad.2xlarge
       wazuh_package_type:
         description: 'Wazuh package type for OVA URL resolution'
         required: true
@@ -116,7 +116,7 @@ on:
       instance_type:
         type: string
         required: false
-        default: 'c5ad.xlarge'
+        default: 'c5ad.2xlarge'
       wazuh_package_type:
         type: string
         required: false

--- a/.github/workflows/test-vm.yaml
+++ b/.github/workflows/test-vm.yaml
@@ -745,8 +745,8 @@ jobs:
           echo "Importing OVA to VirtualBox..."
           ssh ${SSH_OPTIONS} ${SSH_HOST} "VBoxManage import ${{ steps.download.outputs.ova_path }} --vsys 0 --vmname ${VM_NAME}"
 
-          echo "Configuring VM resources (memory: 8192MB, CPUs: 4)..."
-          ssh ${SSH_OPTIONS} ${SSH_HOST} "VBoxManage modifyvm ${VM_NAME} --memory 8192 --cpus 4 --nic1 nat"
+          echo "Configuring VM resources (memory: 16384MB, CPUs: 8)..."
+          ssh ${SSH_OPTIONS} ${SSH_HOST} "VBoxManage modifyvm ${VM_NAME} --memory 16384 --cpus 8 --nic1 nat"
 
           echo "Starting VM in headless mode..."
           ssh ${SSH_OPTIONS} ${SSH_HOST} "VBoxManage startvm ${VM_NAME} --type headless"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Changed OVA and AMI deployment requirements and documentation ([#694](https://github.com/wazuh/wazuh-virtual-machines/pull/694))
 - Reverted PR 641. ([#649](https://github.com/wazuh/wazuh-virtual-machines/pull/649))
 - Fix manager certificates ownership ([#648](https://github.com/wazuh/wazuh-virtual-machines/pull/648))
 - Change artifact suffix and prod and pre-prod urls ([#640](https://github.com/wazuh/wazuh-virtual-machines/pull/640))

--- a/configurer/ova/ova_pre_configurer/static/Vagrantfile
+++ b/configurer/ova/ova_pre_configurer/static/Vagrantfile
@@ -21,8 +21,8 @@ Vagrant.configure("2") do |config|
     #
     config.vm.provider "virtualbox" do |vb|
     #   # Customize the amount of memory on the VM:
-      vb.memory = "8192"
-      vb.cpus = 4
+      vb.memory = "16384"
+      vb.cpus = 8
       vb.customize ["setextradata", :id, "VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled", 1]
       vb.name = "ova_base"
     end

--- a/docs/dev/run-tests/ami/ami-run-tests.md
+++ b/docs/dev/run-tests/ami/ami-run-tests.md
@@ -92,8 +92,8 @@ Trigger AMI integration tests by commenting on the PR:
    - Cleans up build instances
 
 2. **Test AMI**
-   - Launches a `c5ad.xlarge` instance for amd64
-   - Launches a `c6g.xlarge` instance for arm64
+   - Launches a `c5ad.2xlarge` instance for amd64
+   - Launches a `c6g.2xlarge` instance for arm64
    - Runs integration tests on both:
      - Certificates validation
      - Service status checks
@@ -107,8 +107,8 @@ Trigger AMI integration tests by commenting on the PR:
 
 | Architecture | Instance Type | Base AMI |
 |--------------|---------------|----------|
-| amd64 (x86_64) | c5ad.xlarge | Amazon Linux 2023 x86_64 |
-| arm64 (aarch64) | c6g.xlarge | Amazon Linux 2023 ARM64 |
+| amd64 (x86_64) | c5ad.2xlarge | Amazon Linux 2023 x86_64 |
+| arm64 (aarch64) | c6g.2xlarge | Amazon Linux 2023 ARM64 |
 
 ### Resources
 

--- a/docs/ref/installation/ami/ami-installation.md
+++ b/docs/ref/installation/ami/ami-installation.md
@@ -8,7 +8,7 @@ There are two alternatives for deploying a Wazuh instance. You can launch the Wa
 2. Review the information and accept the terms for the software. Click **Continue to Configuration** to confirm subscribing to our Server product.
 3. Select a **Software Version** and the **Region** where the instance is going to be deployed. Then, click **Continue to Launch**.
 4. Review your configuration, making sure that all settings are correct before launching the software. Adapt the default configuration values to your needs.
-    1. **Instance Type**: When selecting the EC2 Instance Type, we recommend that you use an instance type `c5a.xlarge` for `x86_64` arch  or `c6g.xlarge`for `aarch64` arch.
+    1. **Instance Type**: When selecting the EC2 Instance Type, we recommend that you use an instance type `c5a.2xlarge` for `x86_64` arch  or `c6g.2xlarge`for `aarch64` arch.
     2. **Network Settings**: When selecting the **Security Group**, it must be one with the appropriate settings for your Wazuh instance to guarantee the correct operation. You can create a new security group by choosing **Create new based on seller** settings. This new group will have the appropriate settings by default.
 5. Click **Launch** to start the instance.
 
@@ -22,7 +22,7 @@ Once your instance is successfully launched and a few minutes have elapsed, you 
 
 3. Review the Server product characteristics, then click **Continue**. This allows subscribing to our Server product.
 
-4. Select the instance type according to your needs, then click Next: Configure Instance Details. We recommend that you use an instance type `c5a.xlarge` for `x86_64` arch  or `c6g.xlarge`for `aarch64` arch.
+4. Select the instance type according to your needs, then click Next: Configure Instance Details. We recommend that you use an instance type `c5a.2xlarge` for `x86_64` arch  or `c6g.2xlarge`for `aarch64` arch.
 
 5. Configure your instance as needed, then click Next: **Add Storage**.
 

--- a/docs/ref/installation/ova/local-ova-installation.md
+++ b/docs/ref/installation/ova/local-ova-installation.md
@@ -2,7 +2,7 @@
 
 In this section, we describe how to create a virtual machine (VM) in Open Virtual Appliance (OVA) format with the Wazuh manager, dashboard, and indexer components pre-installed. To build it locally, we will use the `wazuh_local_ova` module from the [Wazuh Virtual Machines](https://github.com/wazuh/wazuh-virtual-machines/tree/main/wazuh_local_ova) repository.
 
-You need a system with a minimum of 4 CPU cores and 8 GB of RAM to build the virtual machine. Ensure that these dependencies are installed on the system:
+You need a system with a minimum of 8 CPU cores and 16 GB of RAM to build the virtual machine. Ensure that these dependencies are installed on the system:
 
 - Virtual Box
 - Vagrant

--- a/docs/ref/installation/ova/ova-installation.md
+++ b/docs/ref/installation/ova/ova-installation.md
@@ -43,4 +43,4 @@ ip a
 
 In case of using VirtualBox, once the virtual machine is imported it may run into issues caused by time skew when VirtualBox synchronizes the time of the guest machine. To avoid this situation, enable the **Hardware Clock in UTC Time** option in the **System** tab of the virtual machine configuration.
 
-> **Note:** By default, the network interface type is set to Bridged Adapter. The VM will attempt to obtain an IP address from the network DHCP server. Alternatively, a static IP address can be set by configuring the appropriate network files in the Amazon Linux operating system on which the VM is based.
+> **Note:** By default, the network interface type is set to Bridged Adapter. The VM will attempt to obtain an IP address from the network DHCP server. Alternatively, a static IP address can be set by configuring the appropriate network files in the Amazon Linux 2023 operating system on which the VM is based.

--- a/utils/scripts/ova_build/wazuh_ovf_template
+++ b/utils/scripts/ova_build/wazuh_ovf_template
@@ -30,7 +30,7 @@
     </AnnotationSection>
     <OperatingSystemSection ovf:id="101" vmw:osType="otherLinux64Guest">
       <Info>The kind of installed guest operating system</Info>
-      <Description>Linux - Amazon Linux 2</Description>
+      <Description>Linux - Amazon Linux 2023</Description>
     </OperatingSystemSection>
     <VirtualHardwareSection>
       <Info>Virtual hardware requirements</Info>
@@ -43,18 +43,18 @@
       <Item>
         <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
         <rasd:Description>Number of Virtual CPUs</rasd:Description>
-        <rasd:ElementName>4 virtual CPU(s)</rasd:ElementName>
+        <rasd:ElementName>8 virtual CPU(s)</rasd:ElementName>
         <rasd:InstanceID>1</rasd:InstanceID>
         <rasd:ResourceType>3</rasd:ResourceType>
-        <rasd:VirtualQuantity>4</rasd:VirtualQuantity>
+        <rasd:VirtualQuantity>8</rasd:VirtualQuantity>
       </Item>
       <Item>
         <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
         <rasd:Description>Memory Size</rasd:Description>
-        <rasd:ElementName>8192MB of memory</rasd:ElementName>
+        <rasd:ElementName>16384MB of memory</rasd:ElementName>
         <rasd:InstanceID>2</rasd:InstanceID>
         <rasd:ResourceType>4</rasd:ResourceType>
-        <rasd:VirtualQuantity>8192</rasd:VirtualQuantity>
+        <rasd:VirtualQuantity>16384</rasd:VirtualQuantity>
       </Item>
       <Item>
         <rasd:Address>1</rasd:Address>

--- a/wazuh_local_ova/templates/Vagrantfile.j2
+++ b/wazuh_local_ova/templates/Vagrantfile.j2
@@ -7,8 +7,8 @@ Vagrant.configure("2") do |config|
   config.vm.hostname = "wazuh"
   config.vm.provider "virtualbox" do |vb|
     vb.name = "{{ vm_name }}"
-    vb.memory = "8192"
-    vb.cpus = "4"
+    vb.memory = "16384"
+    vb.cpus = "8"
     vb.customize ["setextradata", :id, "VBoxInternal/Devices/VMMDev/0/Config/GetHostTimeDisabled", 1]
   end
 


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-virtual-machines/issues/688

# Description

The goal of this PR is to update the OVA and AMI deployment requirements to align them with the increased demands of the Wazuh central components.

Tests conducted during various development phases have revealed that our previous requirements (8 GB RAM and 4 vCPUs) may eventually prove insufficient.
For this reason, we have decided to increase the recommended requirements for these deployments to 16 GB RAM and 8 vCPUs.

## OVA

In our build process, the VM that is deployed—on which the core Wazuh components are installed, configured, and then exported as an OVA—has been updated with these requirements.

We have also updated the template for the `.ova` file we distribute, so that by default, when importing this file into the virtualization platform, 16 GB of RAM and 8 vCPUs are allocated. (Users can customize this before launching the VM, but this is what we recommend.)
See: https://github.com/wazuh/wazuh-virtual-machines/issues/688#issuecomment-4314385697.

### AMI

In our build process, the AMI is built by deploying an instance with the internal Allocator module.
Currently, we deploy it using a `c5a.xlarge` instance. We should consider changing this, or at least supporting the `c5a.2xlarge` instance—which meets the requirements mentioned above.

 ### Both Methods

The relevant documentation for both OVA and AMI has been updated to reflect this change. 