### PR TITLE
Change the destination path of the artifact_urls file for pre-release and prod environments

### DIFF
--- a/.github/workflows/builder_OVA.yaml
+++ b/.github/workflows/builder_OVA.yaml
@@ -245,9 +245,9 @@ jobs:
       - name: Get artifacts URLs file
         run: |
           if [ "${{ inputs.wazuh_package_type }}" == "prod" ]; then
-            curl -f "https://${{ vars.PACKAGES_PROD_URL }}/production/${{ env.WAZUH_MAJOR }}.x/artifact_urls_${{ env.WAZUH_VERSION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
+            curl -f "https://${{ vars.PACKAGES_PROD_URL }}/production/${{ env.WAZUH_MAJOR }}.x/artifact-urls/artifact_urls_${{ env.WAZUH_VERSION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
           elif [ "${{ inputs.wazuh_package_type }}" == "pre-prod" ]; then
-            curl -f "https://${{ vars.PACKAGES_STAGING_URL }}/pre-release/${{ env.WAZUH_MAJOR }}.x/artifact_urls_${{ env.WAZUH_VERSION }}-${{ env.WAZUH_REVISION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
+            curl -f "https://${{ vars.PACKAGES_STAGING_URL }}/pre-release/${{ env.WAZUH_MAJOR }}.x/artifact-urls/artifact_urls_${{ env.WAZUH_VERSION }}-${{ env.WAZUH_REVISION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
           else
             LOCAL_AWS_S3_BUCKET_DEV=${{ vars.AWS_S3_BUCKET_DEV }}
             echo LOCAL_AWS_S3_BUCKET_DEV=$LOCAL_AWS_S3_BUCKET_DEV >> $GITHUB_ENV

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -248,7 +248,7 @@ jobs:
           if [ "${{ inputs.wazuh_package_type }}" == "prod" ]; then
             curl -f "https://${{ vars.PACKAGES_PROD_URL }}/production/${{ env.WAZUH_MAJOR }}.x/artifact-urls/artifact_urls_${{ env.WAZUH_VERSION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
           elif [ "${{ inputs.wazuh_package_type }}" == "pre-prod" ]; then
-            curl -f "https://${{ vars.PACKAGES_STAGING_URL }}/pre-release/${{ env.WAZUH_MAJOR }}.x/artifact-urls/artifact_urls_${{ env.WAZUH_VERSION }}-${{ env.WAZUH_REVISION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
+            curl -f "https://${{ vars.PACKAGES_STAGING_URL }}/staging-test/pre-release/5.x/artifact-urls/artifact_urls_5.0.0-alpha99.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
           else
             LOCAL_AWS_S3_BUCKET_DEV=${{ vars.AWS_S3_BUCKET_DEV }}
             echo LOCAL_AWS_S3_BUCKET_DEV=$LOCAL_AWS_S3_BUCKET_DEV >> $GITHUB_ENV

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -248,7 +248,7 @@ jobs:
           if [ "${{ inputs.wazuh_package_type }}" == "prod" ]; then
             curl -f "https://${{ vars.PACKAGES_PROD_URL }}/production/${{ env.WAZUH_MAJOR }}.x/artifact-urls/artifact_urls_${{ env.WAZUH_VERSION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
           elif [ "${{ inputs.wazuh_package_type }}" == "pre-prod" ]; then
-            curl -f "https://${{ vars.PACKAGES_STAGING_URL }}/staging-test/pre-release/5.x/artifact-urls/artifact_urls_5.0.0-alpha99.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
+            curl -f "https://${{ vars.PACKAGES_STAGING_URL }}/pre-release/${{ env.WAZUH_MAJOR }}.x/artifact-urls/artifact_urls_${{ env.WAZUH_VERSION }}-${{ env.WAZUH_REVISION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
           else
             LOCAL_AWS_S3_BUCKET_DEV=${{ vars.AWS_S3_BUCKET_DEV }}
             echo LOCAL_AWS_S3_BUCKET_DEV=$LOCAL_AWS_S3_BUCKET_DEV >> $GITHUB_ENV

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -246,9 +246,9 @@ jobs:
       - name: Get artifacts URLs file
         run: |
           if [ "${{ inputs.wazuh_package_type }}" == "prod" ]; then
-            curl -f "https://${{ vars.PACKAGES_PROD_URL }}/production/${{ env.WAZUH_MAJOR }}.x/artifact_urls_${{ env.WAZUH_VERSION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
+            curl -f "https://${{ vars.PACKAGES_PROD_URL }}/production/${{ env.WAZUH_MAJOR }}.x/artifact-urls/artifact_urls_${{ env.WAZUH_VERSION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
           elif [ "${{ inputs.wazuh_package_type }}" == "pre-prod" ]; then
-            curl -f "https://${{ vars.PACKAGES_STAGING_URL }}/pre-release/${{ env.WAZUH_MAJOR }}.x/artifact_urls_${{ env.WAZUH_VERSION }}-${{ env.WAZUH_REVISION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
+            curl -f "https://${{ vars.PACKAGES_STAGING_URL }}/pre-release/${{ env.WAZUH_MAJOR }}.x/artifact-urls/artifact_urls_${{ env.WAZUH_VERSION }}-${{ env.WAZUH_REVISION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
           else
             LOCAL_AWS_S3_BUCKET_DEV=${{ vars.AWS_S3_BUCKET_DEV }}
             echo LOCAL_AWS_S3_BUCKET_DEV=$LOCAL_AWS_S3_BUCKET_DEV >> $GITHUB_ENV

--- a/.github/workflows/test-vm.yaml
+++ b/.github/workflows/test-vm.yaml
@@ -572,9 +572,9 @@ jobs:
       - name: Get artifacts URLs file
         run: |
           if [ "${{ inputs.wazuh_package_type }}" == "prod" ]; then
-            curl -f "https://${{ vars.PACKAGES_PROD_URL }}/production/${{ env.WAZUH_MAJOR }}.x/artifact_urls_${{ env.WAZUH_VERSION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
+            curl -f "https://${{ vars.PACKAGES_PROD_URL }}/production/${{ env.WAZUH_MAJOR }}.x/artifact-urls/artifact_urls_${{ env.WAZUH_VERSION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
           elif [ "${{ inputs.wazuh_package_type }}" == "pre-prod" ]; then
-            curl -f "https://${{ vars.PACKAGES_STAGING_URL }}/pre-release/${{ env.WAZUH_MAJOR }}.x/artifact_urls_${{ env.WAZUH_VERSION }}-${{ env.WAZUH_REVISION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
+            curl -f "https://${{ vars.PACKAGES_STAGING_URL }}/pre-release/${{ env.WAZUH_MAJOR }}.x/artifact-urls/artifact_urls_${{ env.WAZUH_VERSION }}-${{ env.WAZUH_REVISION }}.yaml" -o ${{ env.LOCAL_ARTIFACT_URLS_FILEPATH }}
           else
             LOCAL_AWS_S3_BUCKET_DEV=${{ vars.AWS_S3_BUCKET_DEV }}
             echo LOCAL_AWS_S3_BUCKET_DEV=$LOCAL_AWS_S3_BUCKET_DEV >> $GITHUB_ENV

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Change the destination path of the artifact_urls file for pre-release and prod environments ([#698](https://github.com/wazuh/wazuh-virtual-machines/pull/698))
 - Changed OVA and AMI deployment requirements and documentation ([#694](https://github.com/wazuh/wazuh-virtual-machines/pull/694))
 - Reverted PR 641. ([#649](https://github.com/wazuh/wazuh-virtual-machines/pull/649))
 - Fix manager certificates ownership ([#648](https://github.com/wazuh/wazuh-virtual-machines/pull/648))

--- a/provisioner/utils/enums.py
+++ b/provisioner/utils/enums.py
@@ -3,7 +3,7 @@ from enum import StrEnum, auto
 
 class AllowedUrlHost(StrEnum):
     RELEASE = "packages.wazuh.com"
-    PRE_RELEASE = "packages-dev.wazuh.com"
+    PRE_RELEASE = "packages-staging.xdrsiem.wazuh.info"
     INTERNAL = "xdrsiem-packages-dev-internal"
 
 

--- a/tests/test_provisioner/test_models/test_input.py
+++ b/tests/test_provisioner/test_models/test_input.py
@@ -140,13 +140,13 @@ def test_inventory_content_no_host_name(mock_open):
 
 @patch("provisioner.models.input.format_passwords_tool_urls_file")
 def test_passwords_tool_url_success(mock_format_passwords_tool_urls_file):
-    mock_format_passwords_tool_urls_file.return_value = "https://packages-dev.wazuh.com/password-tool"
+    mock_format_passwords_tool_urls_file.return_value = "https://packages-staging.xdrsiem.wazuh.info/password-tool"
 
     passwords_tool_content = INPUT_EXAMPLE.passwords_tool_content
 
     mock_format_passwords_tool_urls_file.assert_called_once_with(Path("/path/to/packages_url"))
     assert isinstance(passwords_tool_content, PasswordsToolInfo)
-    assert passwords_tool_content.url == AnyUrl("https://packages-dev.wazuh.com/password-tool")
+    assert passwords_tool_content.url == AnyUrl("https://packages-staging.xdrsiem.wazuh.info/password-tool")
 
 
 @patch("provisioner.models.input.format_passwords_tool_urls_file")

--- a/tests/test_provisioner/test_models/test_utils/test_helpers.py
+++ b/tests/test_provisioner/test_models/test_utils/test_helpers.py
@@ -9,10 +9,10 @@ from provisioner.utils import AllowedUrlHost
     "url",
     [
         "https://packages.wazuh.com/4.x/yum/",
-        "https://packages-dev.wazuh.com/doing/tests"
+        "https://packages-staging.xdrsiem.wazuh.info/doing/tests"
         "htts://xdrsiem-packages-dev-internal"
         "https://packages.wazuh.com"
-        "https://packages-dev.wazuh.com",
+        "https://packages-staging.xdrsiem.wazuh.info",
         "https://xdrsiem-packages-dev-internal",
     ],
 )

--- a/tests/test_provisioner/test_provisioner.py
+++ b/tests/test_provisioner/test_provisioner.py
@@ -24,16 +24,16 @@ def component_info_valid(valid_inventory):
     dependencies = ["dependency1", "dependency2"]
     component_manager = ComponentInfo(
         name=Component.WAZUH_MANAGER,
-        package_url=AnyUrl("http://packages-dev.wazuh.com"),
+        package_url=AnyUrl("http://packages-staging.xdrsiem.wazuh.info"),
         dependencies=dependencies,
     )
     certs = CertsInfo(
         certs_url_content={
-            "certs_tool": "http://packages-dev.wazuh.com/example/certs-tool.sh",
-            "config": "http://packages-dev.wazuh.com/example/config.yml",
+            "certs_tool": "http://packages-staging.xdrsiem.wazuh.info/example/certs-tool.sh",
+            "config": "http://packages-staging.xdrsiem.wazuh.info/example/config.yml",
         }
     )
-    passwords_tool = PasswordsToolInfo(url=AnyUrl("http://packages-dev.wazuh.com/example/passwords-tool.sh"))
+    passwords_tool = PasswordsToolInfo(url=AnyUrl("http://packages-staging.xdrsiem.wazuh.info/example/passwords-tool.sh"))
 
     package_type = Package_type.RPM
     return Provisioner(
@@ -61,9 +61,9 @@ def test_provision_success(mock_paramiko, mock_logger, component_info_valid, moc
     mock_paramiko.return_value = mock_client_instance
 
     tools_expect_commands = [
-        "mkdir -p ~/wazuh-configure/tools/certs && curl -s -o ~/wazuh-configure/tools/certs/certs-tool.sh 'http://packages-dev.wazuh.com/example/certs-tool.sh'",
-        "mkdir -p ~/wazuh-configure/tools/certs && curl -s -o ~/wazuh-configure/tools/certs/config.yml 'http://packages-dev.wazuh.com/example/config.yml'",
-        "mkdir -p ~/wazuh-configure/tools && curl -s -o ~/wazuh-configure/tools/passwords-tool.sh 'http://packages-dev.wazuh.com/example/passwords-tool.sh'",
+        "mkdir -p ~/wazuh-configure/tools/certs && curl -s -o ~/wazuh-configure/tools/certs/certs-tool.sh 'http://packages-staging.xdrsiem.wazuh.info/example/certs-tool.sh'",
+        "mkdir -p ~/wazuh-configure/tools/certs && curl -s -o ~/wazuh-configure/tools/certs/config.yml 'http://packages-staging.xdrsiem.wazuh.info/example/config.yml'",
+        "mkdir -p ~/wazuh-configure/tools && curl -s -o ~/wazuh-configure/tools/passwords-tool.sh 'http://packages-staging.xdrsiem.wazuh.info/example/passwords-tool.sh'",
     ]
 
     dependencies_expect_commands = [
@@ -74,7 +74,7 @@ def test_provision_success(mock_paramiko, mock_logger, component_info_valid, moc
     ]
 
     package_expect_commands = [
-        "mkdir -p ~/wazuh-configure/packages && curl -s -o ~/wazuh-configure/packages/wazuh_manager.rpm 'http://packages-dev.wazuh.com/'",
+        "mkdir -p ~/wazuh-configure/packages && curl -s -o ~/wazuh-configure/packages/wazuh_manager.rpm 'http://packages-staging.xdrsiem.wazuh.info/'",
         "sudo dnf install -y ~/wazuh-configure/packages/wazuh_manager.rpm",
     ]
 
@@ -127,7 +127,7 @@ def test_certs_tool_provision_success(
     getattr(component_info_valid, certs_method)(mock_client_instance)
 
     mock_exec_command.assert_called_once_with(
-        command=f"mkdir -p ~/wazuh-configure/tools/certs && curl -s -o ~/wazuh-configure/tools/certs/{certs_component} 'http://packages-dev.wazuh.com/example/{certs_component}'",
+        command=f"mkdir -p ~/wazuh-configure/tools/certs && curl -s -o ~/wazuh-configure/tools/certs/{certs_component} 'http://packages-staging.xdrsiem.wazuh.info/example/{certs_component}'",
         client=mock_client_instance,
     )
     mock_logger.debug.assert_any_call(f"Provisioning {certs_component}")
@@ -149,7 +149,7 @@ def test_certs_tool_provision_failure(
         getattr(component_info_valid, certs_method)(mock_client_instance)
 
     mock_exec_command.assert_called_once_with(
-        command=f"mkdir -p ~/wazuh-configure/tools/certs && curl -s -o ~/wazuh-configure/tools/certs/{certs_component} 'http://packages-dev.wazuh.com/example/{certs_component}'",
+        command=f"mkdir -p ~/wazuh-configure/tools/certs && curl -s -o ~/wazuh-configure/tools/certs/{certs_component} 'http://packages-staging.xdrsiem.wazuh.info/example/{certs_component}'",
         client=mock_client_instance,
     )
     mock_logger.debug.assert_any_call(f"Provisioning {certs_component}")
@@ -230,7 +230,7 @@ def test_packages_provision_success(
     mock_exec_command.assert_has_calls(
         [
             mock.call(
-                command=f"mkdir -p ~/wazuh-configure/packages && curl -s -o {expected_path} 'http://packages-dev.wazuh.com/'",
+                command=f"mkdir -p ~/wazuh-configure/packages && curl -s -o {expected_path} 'http://packages-staging.xdrsiem.wazuh.info/'",
                 client=mock_client_instance,
             ),
             mock.call(
@@ -250,19 +250,19 @@ def test_packages_provision_success(
         (
             Package_manager.YUM,
             Component.WAZUH_MANAGER,
-            "http://packages-dev.wazuh.com/wazuh_manager.rpm",
+            "http://packages-staging.xdrsiem.wazuh.info/wazuh_manager.rpm",
             "wazuh_manager.rpm",
         ),
         (
             Package_manager.YUM,
             Component.WAZUH_AGENT,
-            "http://packages-dev.wazuh.com/wazuh_agent.rpm",
+            "http://packages-staging.xdrsiem.wazuh.info/wazuh_agent.rpm",
             "wazuh_agent.rpm",
         ),
         (
             Package_manager.APT,
             Component.WAZUH_INDEXER,
-            "http://packages-dev.wazuh.com/wazuh_indexer.deb",
+            "http://packages-staging.xdrsiem.wazuh.info/wazuh_indexer.deb",
             "wazuh_indexer.deb",
         ),
     ],
@@ -295,9 +295,9 @@ def test_get_package_by_url_success(
 @pytest.mark.parametrize(
     "component_name, package_url, error_output",
     [
-        (Component.WAZUH_MANAGER, "http://packages-dev.wazuh.com/wazuh_manager.rpm", "Error output"),
-        (Component.WAZUH_AGENT, "http://packages-dev.wazuh.com/wazuh_agent.rpm", "Error output"),
-        (Component.WAZUH_INDEXER, "http://packages-dev.wazuh.com/wazuh_indexer.deb", "Error output"),
+        (Component.WAZUH_MANAGER, "http://packages-staging.xdrsiem.wazuh.info/wazuh_manager.rpm", "Error output"),
+        (Component.WAZUH_AGENT, "http://packages-staging.xdrsiem.wazuh.info/wazuh_agent.rpm", "Error output"),
+        (Component.WAZUH_INDEXER, "http://packages-staging.xdrsiem.wazuh.info/wazuh_indexer.deb", "Error output"),
     ],
 )
 @patch("paramiko.SSHClient")

--- a/wazuh_local_ova/enums.py
+++ b/wazuh_local_ova/enums.py
@@ -8,8 +8,8 @@ class EnvironmentType(StrEnum):
 
 
 class ArtifactFilePath(StrEnum):
-    RELEASE = "https://packages.wazuh.com/production/{major}.x/artifact_urls_{wazuh-version}.yaml"
-    PRE_RELEASE = "https://packages-staging.xdrsiem.wazuh.info/pre-release/{major}.x/artifact_urls_{wazuh-version}-{wazuh-revision}.yaml"
+    RELEASE = "https://packages.wazuh.com/production/{major}.x/artifact-urls/artifact_urls_{wazuh-version}.yaml"
+    PRE_RELEASE = "https://packages-staging.xdrsiem.wazuh.info/pre-release/{major}.x/artifact-urls/artifact_urls_{wazuh-version}-{wazuh-revision}.yaml"
     DEV = "./artifact_urls.yaml"
 
     def build(self, version: str = "", revision: str = "") -> str:
@@ -30,10 +30,10 @@ class ArtifactFilePath(StrEnum):
 
         Examples:
             >>> ArtifactFilePath.RELEASE.build(version="5.0.0")
-            'https://packages.wazuh.com/production/5.x/artifact_urls_5.0.0.yaml'
+            'https://packages.wazuh.com/production/5.x/artifact-urls/artifact_urls_5.0.0.yaml'
 
             >>> ArtifactFilePath.PRE_RELEASE.build(version="5.0.0", revision="1")
-            'https://packages-staging.xdrsiem.wazuh.info/pre-release/5.x/artifact_urls_5.0.0-1.yaml'
+            'https://packages-staging.xdrsiem.wazuh.info/pre-release/5.x/artifact-urls/artifact_urls_5.0.0-1.yaml'
 
             >>> ArtifactFilePath.DEV.build()
             './artifact_urls.yaml'


### PR DESCRIPTION
# Description

The purpose of this PR is to update the path from which the `artifact_urls` file will be retrieved for both staging and production.

## Other changes

### Updated Pre-release URL

During the changes to the `artifact_urls` path for pre-release, it was also identified that the URL was outdated. It was set to `packages-dev.wazuh.com` instead of `packages-staging.xdrsiem.wazuh.info`. When the code validated whether the package URLs were correct, it failed because the current URL was not included among the list of allowed URLs.

For this reason, the pre-release URL has been updated to `packages-staging.xdrsiem.wazuh.info`.

## Testing 🧪 

A new AMI has been built to verify that the `artifact_urls` file is correctly retrieved. The build process completed successfully.

- https://github.com/wazuh/wazuh-virtual-machines/actions/runs/25056119868