### PR TITLE
Fix AMI ARM build failing when fetching the manager package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix AMI ARM build failing when fetching the manager package ([#745](https://github.com/wazuh/wazuh-virtual-machines/pull/745))
 - Added merge step in bumper workflow. ([#671](https://github.com/wazuh/wazuh-virtual-machines/pull/671))
 - Fixed Wazuh ami default ssh port. ([#641](https://github.com/wazuh/wazuh-virtual-machines/pull/641))
 - Replace incorrect dashboard API check function in AMI customizer ([#636](https://github.com/wazuh/wazuh-virtual-machines/pull/636))

--- a/provisioner/models/utils/file_formatter.py
+++ b/provisioner/models/utils/file_formatter.py
@@ -32,12 +32,18 @@ def file_to_dict(raw_urls_path: Path) -> dict:
 def get_component_packages(raw_urls_content: dict, component: Component) -> dict:
     """
     Extracts and organizes package information for a specified component from raw URL content.
+
+    A key in raw_urls_content is considered a match only if it contains both the component
+    name and one of the supported architectures (from Component_arch), formatted as
+    '{component_name}_{arch}'. This prevents false positives from keys that share a common
+    prefix with the component name.
+
     >>> raw_urls_content = {
-    ...     "wazuh_indexer_url_amd64_deb": "https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/",
-    ...     "wazuh_indexer_url_arm64_deb": "https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/",
-    ...     "wazuh_manager_url_amd64_deb": "https://packages.wazuh.com/wazuh-manager-example/amd64/deb/",
+    ...     "wazuh_indexer_amd64_deb": "https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/",
+    ...     "wazuh_indexer_arm64_deb": "https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/",
+    ...     "wazuh_manager_amd64_deb": "https://packages.wazuh.com/wazuh-manager-example/amd64/deb/",
     ... }
-    >>> component = Component.WAZUH_MANAGER
+    >>> component = Component.WAZUH_INDEXER
     >>> get_component_packages(raw_urls_content, component)
     {'wazuh_indexer': ['https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/', 'https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/']}
 
@@ -46,12 +52,16 @@ def get_component_packages(raw_urls_content: dict, component: Component) -> dict
         component (Component): The component object for which packages need to be extracted.
 
     Returns:
-        dict: A dictionary where the key is the component name (in lowercase) and the value is a list of packages associated with that component.
+        dict: A dictionary where the key is the component name (in lowercase) and the value
+              is a list of package URLs whose keys match '{component_name}_{arch}' for any
+              supported architecture in Component_arch.
     """
     component_packages: dict = {}
 
+    valid_keys = [f"{component.name.lower()}_{arch.lower()}" for arch in Component_arch]
+
     for component_key in raw_urls_content:
-        if component.name.lower() in component_key:
+        if any(valid_key in component_key for valid_key in valid_keys):
             if component.name.lower() not in component_packages:
                 component_packages[component.name.lower()] = []
 
@@ -188,9 +198,9 @@ def format_component_urls_file(raw_urls_path: Path) -> dict:
         raw_urls_path (Path): The path to the raw URLs file.
     >>> raw_urls_path = Path("component_urls.yaml")
     ... raw_urls_content = {
-    ...     "wazuh_indexer_url_amd64_deb": "https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/",
-    ...     "wazuh_indexer_url_arm64_deb": "https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/",
-    ...     "wazuh_manager_url_x86_64_rpm": "https://packages.wazuh.com/wazuh-manager-example/x86_64/rpm/",
+    ...     "wazuh_indexer_amd64_deb": "https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/",
+    ...     "wazuh_indexer_arm64_deb": "https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/",
+    ...     "wazuh_manager_x86_64_rpm": "https://packages.wazuh.com/wazuh-manager-example/x86_64/rpm/",
     ... }
     ... format_component_urls_file(raw_urls_path)
     {'wazuh_indexer': {'deb': {'amd64': 'https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/',

--- a/tests/test_provisioner/test_models/test_utils/test_file_formatter.py
+++ b/tests/test_provisioner/test_models/test_utils/test_file_formatter.py
@@ -35,9 +35,11 @@ def test_file_to_dict_non_existent_file(mock_file):
 
 def test_get_component_packages_valid():
     raw_urls_content = {
-        "wazuh_indexer_url_amd64_deb": "https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/",
-        "wazuh_indexer_url_arm64_deb": "https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/",
-        "wazuh_manager_url_amd64_deb": "https://packages.wazuh.com/wazuh-manager-example/amd64/deb/",
+        "wazuh_indexer_amd64_deb": "https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/",
+        "wazuh_indexer_debug_arm64_deb": "https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/",
+        "wazuh_indexer_arm64_deb": "https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/",
+        "wazuh_manager_amd64_deb": "https://packages.wazuh.com/wazuh-manager-example/amd64/deb/",
+        "wazuh_manager_debug_amd64_deb": "https://packages.wazuh.com/wazuh-manager-example/debug/amd64/deb/",
     }
     component = Component.WAZUH_INDEXER
     expected_output = {
@@ -53,6 +55,7 @@ def test_get_component_packages_no_matching_component():
     raw_urls_content = {
         "wazuh_indexer_url_amd64_deb": "https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/",
         "wazuh_indexer_url_arm64_deb": "https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/",
+        "wazuh_manager_extralines_arm64_deb": "https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/",
     }
     component = Component.WAZUH_MANAGER
     expected_output = {}
@@ -182,10 +185,10 @@ def test_format_certificates_urls_file_partial(mock_file):
     "builtins.open",
     new_callable=mock_open,
     read_data="""
-wazuh_indexer_url_amd64_deb: https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/
-wazuh_indexer_url_arm64_deb: https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/
-wazuh_manager_url_x86_64_rpm: https://packages.wazuh.com/wazuh-manager-example/x86_64/rpm/
-wazuh_agent_url_amd64_deb: https://packages.wazuh.com/wazuh-agent-example/amd64/deb/
+wazuh_indexer_amd64_deb: https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/
+wazuh_indexer_arm64_deb: https://packages.wazuh.com/wazuh-indexer-example/arm64/deb/
+wazuh_manager_extralines_x86_64_rpm: https://packages.wazuh.com/wazuh-manager-example/x86_64/rpm/
+wazuh_agent_amd64_deb: https://packages.wazuh.com/wazuh-agent-example/amd64/deb/
 """,
 )
 def test_format_component_urls_file_valid(mock_file):
@@ -197,12 +200,7 @@ def test_format_component_urls_file_valid(mock_file):
             },
             "rpm": {},
         },
-        "wazuh_manager": {
-            "deb": {},
-            "rpm": {
-                "x86_64": "https://packages.wazuh.com/wazuh-manager-example/x86_64/rpm/",
-            },
-        },
+        "wazuh_manager": {"deb": {}, "rpm": {}},
         "wazuh_dashboard": {"deb": {}, "rpm": {}},
         "wazuh_agent": {
             "deb": {
@@ -224,8 +222,8 @@ def test_format_component_urls_file_empty(mock_file):
     "builtins.open",
     new_callable=mock_open,
     read_data="""
-wazuh_indexer_url_amd64_deb: https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/
-wazuh_manager_url_arm64_rpm: https://packages.wazuh.com/wazuh-manager-example/x86_64/rpm/
+wazuh_indexer_amd64_deb: https://packages.wazuh.com/wazuh-indexer-example/amd64/deb/
+wazuh_manager_arm64_rpm: https://packages.wazuh.com/wazuh-manager-example/x86_64/rpm/
 """,
 )
 def test_format_component_urls_file_partial(mock_file):

--- a/tests/test_provisioner/test_provisioner.py
+++ b/tests/test_provisioner/test_provisioner.py
@@ -33,7 +33,9 @@ def component_info_valid(valid_inventory):
             "config": "http://packages-staging.xdrsiem.wazuh.info/example/config.yml",
         }
     )
-    passwords_tool = PasswordsToolInfo(url=AnyUrl("http://packages-staging.xdrsiem.wazuh.info/example/passwords-tool.sh"))
+    passwords_tool = PasswordsToolInfo(
+        url=AnyUrl("http://packages-staging.xdrsiem.wazuh.info/example/passwords-tool.sh")
+    )
 
     package_type = Package_type.RPM
     return Provisioner(


### PR DESCRIPTION
# Description

This PR fixes issue [#744](https://github.com/wazuh/wazuh-virtual-machines/issues/744), in which the AMI ARM build was failing to fetch the correct manager package.

The root cause was in `get_component_packages` (`provisioner/models/utils/file_formatter.py`): the function matched any key in the URLs file that simply contained the component name as a substring. This was too broad — a key like `wazuh_manager_debug_arm64_rpm` would incorrectly match for `wazuh_manager`, causing unexpected packages to be included in the resolution chain. As a result, architecture lookup could return a wrong or missing URL for the ARM package.

The fix narrows the matching condition: a key is now only accepted if it contains `{component_name}_{arch}` for one of the architectures explicitly declared in `Component_arch` (i.e. `amd64`, `x86_64`, `arm64`, `aarch64`). This guarantees that only canonical, architecture-scoped keys are picked up for each component.

## Testing

- Build workflow:  https://github.com/wazuh/wazuh-virtual-machines/actions/runs/25674143157