### PR TITLE
Added RecommendedInstanceType to the AMI builds

### DIFF
--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -366,8 +366,14 @@ jobs:
             DEV_TAG_VALUE="True"
           fi
 
+          if [ "${{ matrix.arch }}" == "arm64" ]; then
+            RECOMMENDED_INSTANCE_TYPE="c6g.2xlarge"
+          else
+            RECOMMENDED_INSTANCE_TYPE="c5a.2xlarge"
+          fi
+
           # Tag AMI
-          TAGS="Key=Name,Value=${{ env.AMI_NAME }} Key=Dev,Value=$DEV_TAG_VALUE Key=WorkflowRun,Value=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          TAGS="Key=Name,Value=${{ env.AMI_NAME }} Key=Dev,Value=$DEV_TAG_VALUE Key=WorkflowRun,Value=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Key=RecommendedInstanceType,Value=$RECOMMENDED_INSTANCE_TYPE"
 
           if [ -n "${{ env.ISSUE_TAG_KEY }}" ]; then
             TAGS="$TAGS Key=${{ env.ISSUE_TAG_KEY }},Value=${{ env.ISSUE_TAG_VALUE }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added RecommendedInstanceType to the AMI builds ([#756](https://github.com/wazuh/wazuh-virtual-machines/pull/756))
 - Added identifier to OVA BOX sha512 URI ([#701](https://github.com/wazuh/wazuh-virtual-machines/pull/701))
 - Added 5.x bumper revert changes ([#684](https://github.com/wazuh/wazuh-virtual-machines/pull/684))
 - Added set-as-main option to repository bumper. ([#663](https://github.com/wazuh/wazuh-virtual-machines/pull/663))


### PR DESCRIPTION
## Related issue
- https://github.com/wazuh/wazuh-virtual-machines/issues/755

# Description

The aim of this PR is to include a new tag for the AMIs created with the recommended instance type.

## Tests

You can see a test in [this comment](https://github.com/wazuh/wazuh-virtual-machines/issues/755#issuecomment-4460085590).