### PR TITLE
Add open and reopened types for pull requests trigger in check_unit_tests workflow

### DIFF
--- a/.github/workflows/check_unit_test.yaml
+++ b/.github/workflows/check_unit_test.yaml
@@ -3,7 +3,7 @@ name: PR Check - Unit Tests
 
 on:
   pull_request:
-    types: [ready_for_review, synchronize]
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add open and reopened types for pull requests trigger in check_unit_tests workflow ([#759](https://github.com/wazuh/wazuh-virtual-machines/pull/759))
 - Added updating os.yml with the latest stage AMIs ([#752](https://github.com/wazuh/wazuh-virtual-machines/pull/752))
 - Added RecommendedInstanceType to the AMI builds ([#756](https://github.com/wazuh/wazuh-virtual-machines/pull/756))
 - Added identifier to OVA BOX sha512 URI ([#701](https://github.com/wazuh/wazuh-virtual-machines/pull/701))


### PR DESCRIPTION
## Description

The “opened” and “reopened” statuses have been added to the pull request trigger types in the unit test check workflow.