### PR TITLE
Add `purpose` input to the build ami workflow

### DIFF
--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -22,8 +22,14 @@ on:
         required: false
       purpose:
         description: "Purpose of the AMI build (e.g., nightly)"
-        type: string
-        required: false
+        type: choice
+        options:
+          - nightly
+          - development
+          - release
+          - pre-release
+        required: true
+        default: development
       ami_revision:
         description: |
           'For AMI candidates must be a number, e,g: 1.'
@@ -367,18 +373,6 @@ jobs:
       - name: Tag AMI
         if: success()
         run: |
-          if [ "${{ inputs.is_stage }}" == "true" ]; then
-            DEV_TAG_VALUE="False"
-          else
-            DEV_TAG_VALUE="True"
-          fi
-
-          # if purpose exists
-          if [ -n "${{ inputs.purpose }}" ]; then
-            PURPOSE_TAG_VALUE="${{ inputs.purpose }}"
-          else
-            PURPOSE_TAG_VALUE="Not specified"
-          fi
           
           if [ "${{ matrix.arch }}" == "arm64" ]; then
             RECOMMENDED_INSTANCE_TYPE="c6g.2xlarge"
@@ -387,7 +381,7 @@ jobs:
           fi
 
           # Tag AMI
-          TAGS="Key=Name,Value=${{ env.AMI_NAME }} Key=Dev,Value=$DEV_TAG_VALUE Key=Purpose,Value=$PURPOSE_TAG_VALUE Key=WorkflowRun,Value=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Key=RecommendedInstanceType,Value=$RECOMMENDED_INSTANCE_TYPE"
+          TAGS="Key=Name,Value=${{ env.AMI_NAME }} Key=Dev,Value=$DEV_TAG_VALUE Key=Purpose,Value=${{ inputs.purpose }} Key=WorkflowRun,Value=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Key=RecommendedInstanceType,Value=$RECOMMENDED_INSTANCE_TYPE"
 
           if [ -n "${{ env.ISSUE_TAG_KEY }}" ]; then
             TAGS="$TAGS Key=${{ env.ISSUE_TAG_KEY }},Value=${{ env.ISSUE_TAG_VALUE }}"
@@ -466,7 +460,7 @@ jobs:
 
   update_os_yml:
     needs: Build_AMI
-    if: always() && inputs.is_stage == true && inputs.is_nightly == false
+    if: always() && inputs.is_stage == true && (inputs.purpose == 'release' || inputs.purpose == 'pre-release')
     runs-on:
       group: wz-linux-amd64
     steps:

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -23,7 +23,7 @@ on:
       is_nightly:
         description: "Is nightly build?"
         type: boolean
-        required: false       
+        required: false
         default: false
       ami_revision:
         description: |
@@ -85,7 +85,7 @@ on:
         default: false
       is_nightly:
         type: boolean
-        required: false      
+        required: false
         default: false
       ami_revision:
         type: string

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -380,7 +380,7 @@ jobs:
           fi
 
           # Tag AMI
-          TAGS="Key=Name,Value=${{ env.AMI_NAME }} Key=Dev,Value=$DEV_TAG_VALUE Key=Purpose,Value=${{ inputs.purpose }} Key=WorkflowRun,Value=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Key=RecommendedInstanceType,Value=$RECOMMENDED_INSTANCE_TYPE"
+          TAGS="Key=Name,Value=${{ env.AMI_NAME }} Key=Purpose,Value=${{ inputs.purpose }} Key=WorkflowRun,Value=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Key=RecommendedInstanceType,Value=$RECOMMENDED_INSTANCE_TYPE"
 
           if [ -n "${{ env.ISSUE_TAG_KEY }}" ]; then
             TAGS="$TAGS Key=${{ env.ISSUE_TAG_KEY }},Value=${{ env.ISSUE_TAG_VALUE }}"

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -20,11 +20,10 @@ on:
         type: boolean
         default: false
         required: false
-      is_nightly:
-        description: "Is nightly build?"
-        type: boolean
+      purpose:
+        description: "Purpose of the AMI build (e.g., nightly)"
+        type: string
         required: false
-        default: false
       ami_revision:
         description: |
           'For AMI candidates must be a number, e,g: 1.'
@@ -83,10 +82,9 @@ on:
         type: boolean
         required: false
         default: false
-      is_nightly:
-        type: boolean
+      purpose:
+        type: string
         required: false
-        default: false
       ami_revision:
         type: string
         required: false
@@ -375,10 +373,11 @@ jobs:
             DEV_TAG_VALUE="True"
           fi
 
-          if [ "${{ inputs.is_nightly }}" == "true" ]; then
-            NIGHTLY_TAG_VALUE="True"
+          # if purpose exists
+          if [ -n "${{ inputs.purpose }}" ]; then
+            PURPOSE_TAG_VALUE="${{ inputs.purpose }}"
           else
-            NIGHTLY_TAG_VALUE="False"
+            PURPOSE_TAG_VALUE="Not specified"
           fi
           
           if [ "${{ matrix.arch }}" == "arm64" ]; then
@@ -388,7 +387,7 @@ jobs:
           fi
 
           # Tag AMI
-          TAGS="Key=Name,Value=${{ env.AMI_NAME }} Key=Dev,Value=$DEV_TAG_VALUE Key=Nightly,Value=$NIGHTLY_TAG_VALUE Key=WorkflowRun,Value=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Key=RecommendedInstanceType,Value=$RECOMMENDED_INSTANCE_TYPE"
+          TAGS="Key=Name,Value=${{ env.AMI_NAME }} Key=Dev,Value=$DEV_TAG_VALUE Key=Purpose,Value=$PURPOSE_TAG_VALUE Key=WorkflowRun,Value=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Key=RecommendedInstanceType,Value=$RECOMMENDED_INSTANCE_TYPE"
 
           if [ -n "${{ env.ISSUE_TAG_KEY }}" ]; then
             TAGS="$TAGS Key=${{ env.ISSUE_TAG_KEY }},Value=${{ env.ISSUE_TAG_VALUE }}"

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -20,6 +20,11 @@ on:
         type: boolean
         default: false
         required: false
+      is_nightly:
+        description: "Is nightly build?"
+        type: boolean
+        required: false       
+        default: false
       ami_revision:
         description: |
           'For AMI candidates must be a number, e,g: 1.'
@@ -77,6 +82,10 @@ on:
       is_stage:
         type: boolean
         required: false
+        default: false
+      is_nightly:
+        type: boolean
+        required: false      
         default: false
       ami_revision:
         type: string
@@ -366,6 +375,12 @@ jobs:
             DEV_TAG_VALUE="True"
           fi
 
+          if [ "${{ inputs.is_nightly }}" == "true" ]; then
+            NIGHTLY_TAG_VALUE="True"
+          else
+            NIGHTLY_TAG_VALUE="False"
+          fi
+          
           if [ "${{ matrix.arch }}" == "arm64" ]; then
             RECOMMENDED_INSTANCE_TYPE="c6g.2xlarge"
           else
@@ -373,7 +388,7 @@ jobs:
           fi
 
           # Tag AMI
-          TAGS="Key=Name,Value=${{ env.AMI_NAME }} Key=Dev,Value=$DEV_TAG_VALUE Key=WorkflowRun,Value=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Key=RecommendedInstanceType,Value=$RECOMMENDED_INSTANCE_TYPE"
+          TAGS="Key=Name,Value=${{ env.AMI_NAME }} Key=Dev,Value=$DEV_TAG_VALUE Key=Nightly,Value=$NIGHTLY_TAG_VALUE Key=WorkflowRun,Value=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} Key=RecommendedInstanceType,Value=$RECOMMENDED_INSTANCE_TYPE"
 
           if [ -n "${{ env.ISSUE_TAG_KEY }}" ]; then
             TAGS="$TAGS Key=${{ env.ISSUE_TAG_KEY }},Value=${{ env.ISSUE_TAG_VALUE }}"
@@ -452,7 +467,7 @@ jobs:
 
   update_os_yml:
     needs: Build_AMI
-    if: always() && inputs.is_stage == true
+    if: always() && inputs.is_stage == true && inputs.is_nightly == false
     runs-on:
       group: wz-linux-amd64
     steps:

--- a/.github/workflows/packages_builder_ami.yaml
+++ b/.github/workflows/packages_builder_ami.yaml
@@ -373,7 +373,6 @@ jobs:
       - name: Tag AMI
         if: success()
         run: |
-          
           if [ "${{ matrix.arch }}" == "arm64" ]; then
             RECOMMENDED_INSTANCE_TYPE="c6g.2xlarge"
           else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add purpose input to the build ami workflow ([#773](https://github.com/wazuh/wazuh-virtual-machines/pull/773))
 - Added download urls for Wazuh OVA file. ([#758](https://github.com/wazuh/wazuh-virtual-machines/pull/758))
 - Add open and reopened types for pull requests trigger in check_unit_tests workflow ([#759](https://github.com/wazuh/wazuh-virtual-machines/pull/759))
 - Added updating os.yml with the latest stage AMIs ([#752](https://github.com/wazuh/wazuh-virtual-machines/pull/752))

--- a/docs/dev/generate-artifact/ami/ami-generate-artifact.md
+++ b/docs/dev/generate-artifact/ami/ami-generate-artifact.md
@@ -67,14 +67,17 @@ This workflow accepts the following inputs:
 - `id`: Unique identifier for the workflow run.
 - `wazuh_virtual_machines_reference`: Branch or tag of the `wazuh-virtual-machines` repository.
 - `wazuh_automation_reference`: Branch or tag of the `wazuh-automation` repository.
+- `is_stage`: Whether this is a stage build. When `true`, the AMI name will not include the commit SHA suffix.
+- `purpose`: Purpose of the AMI build. Options: `nightly`, `development`, `release`, `pre-release`. Used as a tag on the resulting AMI.
 - `ami_revision`: Suffix for the AMI name.
-  For AMI candidates, this must be a number (e.g., `-1`).
-  For development AMIs, you can use a different format (e.g., `-dev`).
-- `wazuh_package_type`: Package type used for the AMI: `release`, `pre-release`, or `dev`.
-- `architecture`: Determine the architecture. It must be a string list (JSON format). E.g: ["amd64", "arm64"]
-- `commit_list`: Wazuh components revisions (comma-separated string list) ["indexer-revision", "manager-revision", "dashboard-revision"]'
-          (Only needed if the Wazuh package type is dev-latest or dev-commit)
-- `customizer_debug`: Enable debug mode in the AMI customizer
+  For AMI candidates, this must be a number (e.g., `1`).
+  For development AMIs, you can use a different format (e.g., `dev`).
+- `wazuh_package_type`: Package type used for the AMI: `prod`, `pre-prod`, or `dev`.
+- `architecture`: Determine the architecture. It must be a string list (JSON format). E.g: `["amd64", "arm64"]`
+- `commit_list`: Wazuh components revisions (JSON list) `["indexer-revision", "manager-revision", "dashboard-revision", "agent-revision", "assistant-revision"]`.
+  Only needed if `wazuh_package_type` is `dev`.
+- `customizer_debug`: Enable debug mode in the AMI customizer.
+- `issue`: URL of the GitHub issue related to this build. Must be a valid `https://github.com/wazuh/` URL.
 - `destroy`: If set, the EC2 instance used for building the AMI will be destroyed once complete.
 
 The resulting AMI will be stored in **AWS**.


### PR DESCRIPTION
## Description

The purpose of this PR is to create the input `purpose` field, where we specify the build's purpose in the AMI build. For now, it supports the options `nightly`, `development`, `release`, and `pre-release`.

Additionally, the `Dev` tag is being removed so that the `purpose:development` tag can function accordingly.

## Testing 🧪 

- https://github.com/wazuh/wazuh-virtual-machines/actions/runs/26452334614