### PR TITLE
Set Wazuh indexer heap size to a quarter of the total RAM memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Changed
 
+- Set Wazuh indexer heap size to a quarter of the total RAM memory ([#859](https://github.com/wazuh/wazuh-virtual-machines/issues/859))
 - Add new WF for changelog check ([#874](https://github.com/wazuh/wazuh-virtual-machines/pull/874))
 - Change upload and download methods ([#844](https://github.com/wazuh/wazuh-virtual-machines/pull/844))
 - Set Authd password in Wazuh agent installation ([#857](https://github.com/wazuh/wazuh-virtual-machines/issues/857))

--- a/configurer/ami/ami_pre_configurer/ami_pre_configurer.py
+++ b/configurer/ami/ami_pre_configurer/ami_pre_configurer.py
@@ -411,6 +411,8 @@ class AmiPreConfigurer:
         Creates and configures a systemd service to set the appropiate ram usage for the indexer's jvm
         on a remote host.
 
+        The uploaded script sets the Wazuh Indexer heap to a quarter of the total RAM of the final host.
+
         This method uploads the necessary service and script files to the remote host,
         moves them to their appropriate locations, sets the required permissions, and
         enables the service using systemd.

--- a/configurer/ami/main.py
+++ b/configurer/ami/main.py
@@ -20,7 +20,7 @@ def ami_pre_configurer(inventory: Inventory) -> str:
        - Configures the MOTD (Message of The Day) with Wazuh branding
        - Stops journald log storage to prevent excessive logging
        - Creates and enables a service to automatically set Wazuh Indexer's JVM heap size
-         based on available system RAM
+         to a quarter of the final host's total RAM.
 
     Args:
         inventory_path (Path): Path to the inventory file.

--- a/configurer/ova/ova_post_configurer/ova_post_configurer.py
+++ b/configurer/ova/ova_post_configurer/ova_post_configurer.py
@@ -74,7 +74,7 @@ def enable_fips() -> None:
 def update_jvm_heap() -> None:
     """
     Updates the JVM heap configuration. This is done through the automatic_set_ram.sh script.
-    This script sets the WAzuh Indexer heap to the half of the total VM RAM memory.
+    This script sets the Wazuh Indexer heap to a quarter of the final host's total RAM memory.
 
     Steps performed:
     1. Copies the `automatic_set_ram.sh` script from the static path to `/etc/automatic_set_ram.sh`.

--- a/docs/ref/modules/configurer/post/ova/post-ova.md
+++ b/docs/ref/modules/configurer/post/ova/post-ova.md
@@ -9,7 +9,7 @@ Once the **Provisioner and Core Configurer** have been executed, the Wazuh compo
 
 1. **GRUB bootloader** is configured to display an image with the **Wazuh logo** when loading the VM.  
 2. **FIPS** (Federal Information Processing Standards) is enabled on the VM.  
-3. **JVM** heap size is updated to half of the total RAM.  
+3. **JVM** heap size is updated to a quarter of the total RAM. The `updateIndexerHeap.service` runs on the first boot of the deployed VM, so the heap is sized against the RAM of the final host.
 4. Added `wazuh-starter` service which is responsible for raising each Wazuh component correctly.  
 5. Changed the `root` password to `wazuh`.  
 6. Changed the VM hostname to `wazuh`.  

--- a/docs/ref/modules/configurer/pre/ami/pre-ami.md
+++ b/docs/ref/modules/configurer/pre/ami/pre-ami.md
@@ -8,6 +8,7 @@ The AMI pre-configuration step includes several system-level tasks to prepare th
 - Changing the machine’s hostname.
 - Modifying various files from the base image.
 - Creating necessary directories for the post-configurer to run.
+- Creating a service (`updateIndexerHeap.service`) that sets the Wazuh Indexer JVM heap size to a quarter of the total RAM. It runs on the first boot of the deployed instance, so the heap is sized against the RAM of the final host.
 
 These changes prepare the AMI environment to continue with the full configuration process.
 

--- a/utils/scripts/automatic_set_ram.sh
+++ b/utils/scripts/automatic_set_ram.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 
 # Configure JVM options for Wazuh indexer
+# Set the heap size to a quarter of the host's total RAM memory.
 ram_mb=$(free -m | awk '/^Mem:/{print $2}')
-ram="$(( ram_mb / 2 ))"
+ram="$(( ram_mb / 4 ))"
 
 if [ "${ram}" -eq "0" ]; then
     ram=1024;


### PR DESCRIPTION
# Description

The aim of this PR is to set the Wazuh indexer heap memory size to a quarter of the total RAM memory of the host.

The update has been done in the `automatic_set_ram.sh` script that is executed in both AMI and OVA customizer processes.

## Tests

You can see tests in [this comment](https://github.com/wazuh/wazuh-virtual-machines/issues/859#issuecomment-4971020005). I tested deploying an OVA with less RAM than recommended and the heap size is adjusted dinamically (in case we have to change requirements in the future).