### PR TITLE
Update CHANGELOG.md format (#3647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,87 +2,99 @@
 
 ### Added
 
-- Add bump-issue-link support for Revert Stage Bump in wazuh-virtual-machines ([#807](https://github.com/wazuh/wazuh-virtual-machines/issues/807))
-- Add integration test module docs ([#835](https://github.com/wazuh/wazuh-virtual-machines/pull/835))
-- Add purpose input to the build ami workflow ([#773](https://github.com/wazuh/wazuh-virtual-machines/pull/773))
-- Update OVA documentation to include the download URL ([#734](https://github.com/wazuh/wazuh-virtual-machines/issues/734))
-- Add open and reopened types for pull requests trigger in check_unit_tests workflow ([#759](https://github.com/wazuh/wazuh-virtual-machines/pull/759))
-- Update os.yml file with the latest stage AMIs ([#716](https://github.com/wazuh/wazuh-virtual-machines/issues/716))
-- Add a new tag attribute to the AMI builder process ([#755](https://github.com/wazuh/wazuh-virtual-machines/issues/755))
-- Change the key of the generated `.box` sha512 URI in OVA generate workflow ([#691](https://github.com/wazuh/wazuh-virtual-machines/issues/691))
-- Support Revert bump functionality in wazuh-virtual-machines ([#673](https://github.com/wazuh/wazuh-virtual-machines/issues/673))
-- Add `--set-as-main` flag support to repository bumper — `wazuh-virtual-machines` ([#642](https://github.com/wazuh/wazuh-virtual-machines/issues/642))
-- Share AMI with `wazuh-dev` and `xdrsiem-dev` AWS accounts ([#427](https://github.com/wazuh/wazuh-virtual-machines/issues/427))
-- Environment selection for local OVA builds and AL2023 box integration ([#628](https://github.com/wazuh/wazuh-virtual-machines/issues/628))
-- Development - Separate Agent/Manager - VMs - Update documentation ([#571](https://github.com/wazuh/wazuh-virtual-machines/issues/571))
-- Development - Separate Agent/Manager - VMs - Ensure the Wazuh agent is stopped in the AMI customization process ([#570](https://github.com/wazuh/wazuh-virtual-machines/issues/570))
-- Development - Separate Agent/Manager - VMs - Add Wazuh agent clean up in the AMI `post configurer` module ([#568](https://github.com/wazuh/wazuh-virtual-machines/issues/568))
-- URL presigned file -  Verify that the OVA and AMI packages comply with the development naming convention. ([#596](https://github.com/wazuh/wazuh-virtual-machines/issues/596))
-- Development - Separate Agent/Manager - VMs - Configure the Wazuh agent in the `core configurer` module ([#567](https://github.com/wazuh/wazuh-virtual-machines/issues/567))
-- Development - Separate Agent/Manager - VMs - Add the Wazuh agent installation in the provisioner module ([#566](https://github.com/wazuh/wazuh-virtual-machines/issues/566))
-- Update Ova documentation with local build ([#545](https://github.com/wazuh/wazuh-virtual-machines/issues/545))
-- Add the installation assistant tools revision in the generate presigned urls script ([#531](https://github.com/wazuh/wazuh-virtual-machines/pull/531))
-- ARM AMI - Ensure functional parity between ARM64 and AMD64 AMIs ([#504](https://github.com/wazuh/wazuh-virtual-machines/issues/504))
+
+| Issue | Comment |
+| - | - |
+| [#807](https://github.com/wazuh/wazuh-virtual-machines/issues/807) | Add bump-issue-link support for Revert Stage Bump in wazuh-virtual-machines |
+| [#835](https://github.com/wazuh/wazuh-virtual-machines/pull/835) | Add integration test module docs |
+| [#773](https://github.com/wazuh/wazuh-virtual-machines/pull/773) | Add purpose input to the build ami workflow |
+| [#734](https://github.com/wazuh/wazuh-virtual-machines/issues/734) | Update OVA documentation to include the download URL |
+| [#759](https://github.com/wazuh/wazuh-virtual-machines/pull/759) | Add open and reopened types for pull requests trigger in check_unit_tests workflow |
+| [#716](https://github.com/wazuh/wazuh-virtual-machines/issues/716) | Update os.yml file with the latest stage AMIs |
+| [#755](https://github.com/wazuh/wazuh-virtual-machines/issues/755) | Add a new tag attribute to the AMI builder process |
+| [#691](https://github.com/wazuh/wazuh-virtual-machines/issues/691) | Change the key of the generated `.box` sha512 URI in OVA generate workflow |
+| [#673](https://github.com/wazuh/wazuh-virtual-machines/issues/673) | Support Revert bump functionality in wazuh-virtual-machines |
+| [#642](https://github.com/wazuh/wazuh-virtual-machines/issues/642) | Add `--set-as-main` flag support to repository bumper — `wazuh-virtual-machines` |
+| [#427](https://github.com/wazuh/wazuh-virtual-machines/issues/427) | Share AMI with `wazuh-dev` and `xdrsiem-dev` AWS accounts |
+| [#628](https://github.com/wazuh/wazuh-virtual-machines/issues/628) | Environment selection for local OVA builds and AL2023 box integration |
+| [#571](https://github.com/wazuh/wazuh-virtual-machines/issues/571) | Development - Separate Agent/Manager - VMs - Update documentation |
+| [#570](https://github.com/wazuh/wazuh-virtual-machines/issues/570) | Development - Separate Agent/Manager - VMs - Ensure the Wazuh agent is stopped in the AMI customization process |
+| [#568](https://github.com/wazuh/wazuh-virtual-machines/issues/568) | Development - Separate Agent/Manager - VMs - Add Wazuh agent clean up in the AMI `post configurer` module |
+| [#596](https://github.com/wazuh/wazuh-virtual-machines/issues/596) | URL presigned file -  Verify that the OVA and AMI packages comply with the development naming convention. |
+| [#567](https://github.com/wazuh/wazuh-virtual-machines/issues/567) | Development - Separate Agent/Manager - VMs - Configure the Wazuh agent in the `core configurer` module |
+| [#566](https://github.com/wazuh/wazuh-virtual-machines/issues/566) | Development - Separate Agent/Manager - VMs - Add the Wazuh agent installation in the provisioner module |
+| [#545](https://github.com/wazuh/wazuh-virtual-machines/issues/545) | Update Ova documentation with local build |
+| [#531](https://github.com/wazuh/wazuh-virtual-machines/pull/531) | Add the installation assistant tools revision in the generate presigned urls script |
+| [#504](https://github.com/wazuh/wazuh-virtual-machines/issues/504) | ARM AMI - Ensure functional parity between ARM64 and AMD64 AMIs |
 
 ### Changed
 
-- Error on AMI and OVA Build ([#883](https://github.com/wazuh/wazuh-virtual-machines/issues/883))
-- Update deployment for Wazuh Indexer 5.0.0 RBAC (VMs) ([#872](https://github.com/wazuh/wazuh-virtual-machines/issues/872))
-- Modify the Wazuh indexer heap size ([#859](https://github.com/wazuh/wazuh-virtual-machines/issues/859))
-- Add new WF for changelog check ([#874](https://github.com/wazuh/wazuh-virtual-machines/pull/874))
-- Change upload and download methods ([#844](https://github.com/wazuh/wazuh-virtual-machines/pull/844))
-- Set authd password in agents installation ([#857](https://github.com/wazuh/wazuh-virtual-machines/issues/857))
-- Change file and workflow names for PR revamp. ([#813](https://github.com/wazuh/wazuh-virtual-machines/pull/813))
-- Changed runners to AWS CodeBuild for main branch ([#820](https://github.com/wazuh/wazuh-virtual-machines/pull/820))
-- Update the deleted indexes in OVA and AMI builds ([#779](https://github.com/wazuh/wazuh-virtual-machines/issues/779))
-- Change the destination path of the artifact_urls file in wazuh-virtual-machines ([#679](https://github.com/wazuh/wazuh-virtual-machines/issues/679))
-- Update the hardware required for OVA and AMI 5.0.0 ([#688](https://github.com/wazuh/wazuh-virtual-machines/issues/688))
-- Reverted PR 641. ([#649](https://github.com/wazuh/wazuh-virtual-machines/pull/649))
-- Virtual machines - Ensure correct Wazuh manager certificates ownership ([#647](https://github.com/wazuh/wazuh-virtual-machines/issues/647))
-- Change artifact suffix and prod and pre-prod urls ([#640](https://github.com/wazuh/wazuh-virtual-machines/pull/640))
-- Wazuh virtual machines - Review and update the passwords tool's naming conventions ([#635](https://github.com/wazuh/wazuh-virtual-machines/issues/635))
-- Updated wazuh-virtual-machines documentation config and tooling versions to meet new standards. ([#631](https://github.com/wazuh/wazuh-virtual-machines/pull/631))
-- Decouple EC2 bare metal termination from GHA workflow in OVA build and monitor termination failures via EventBridge ([#584](https://github.com/wazuh/wazuh-virtual-machines/issues/584))
-- Update artifact generation jobs to use wz-linux dedicated runner group ([#621](https://github.com/wazuh/wazuh-virtual-machines/pull/621))
-- URL presigned file - Update the Wazuh virtual machines arctifact creation workflows ([#599](https://github.com/wazuh/wazuh-virtual-machines/issues/599))
-- Development - Separate Agent/Manager - VMs - Add Wazuh agent clean up in the OVA `post configurer` module ([#569](https://github.com/wazuh/wazuh-virtual-machines/issues/569))
-- Wazuh Manager/agent Separation - Breaking changes summary ([#610](https://github.com/wazuh/wazuh-virtual-machines/issues/610))
-- Addapt Builder OVA and AMI to execute test WF ([#578](https://github.com/wazuh/wazuh-virtual-machines/issues/578))
-- Development - Separate Agent/Manager - VMs - Update the Wazuh Manager path references to `/var/wazuh-manager/` ([#564](https://github.com/wazuh/wazuh-virtual-machines/issues/564))
-- Adapt the integration test module ([#548](https://github.com/wazuh/wazuh-virtual-machines/issues/548))
-- Duplicate AMI name in CreateImage in AWS EC2 ([#549](https://github.com/wazuh/wazuh-virtual-machines/issues/549))
-- Change URL sign expiration time and add debug messages ([#553](https://github.com/wazuh/wazuh-virtual-machines/pull/553))
-- Update the OVA and AMI workflow upload a latest arctifact in case of is_stage == false ([#526](https://github.com/wazuh/wazuh-virtual-machines/issues/526))
-- Adapt password change in AMI build to new restrictions ([#516](https://github.com/wazuh/wazuh-virtual-machines/issues/516))
-- ARM AMI - Update Wazuh AMI guides for ARM64 support ([#506](https://github.com/wazuh/wazuh-virtual-machines/issues/506))
-- OVA composite names update ([#510](https://github.com/wazuh/wazuh-virtual-machines/pull/510))
-- ARM AMI - Adapt Wazuh AMI generation code for ARM64 support ([#503](https://github.com/wazuh/wazuh-virtual-machines/issues/503))
-- Development - DevOps 5.0 adaptation - AMI & OVA - Update the path to the development URL file in the build workflows ([#451](https://github.com/wazuh/wazuh-virtual-machines/issues/451))
-- Development - DevOps 5.0 adaptation - AMI - Password tool development ([#450](https://github.com/wazuh/wazuh-virtual-machines/issues/450))
-- Development - DevOps 5.0 adaptation - OVA - Adapt the uploading AWS S3 path for the OVA ([#456](https://github.com/wazuh/wazuh-virtual-machines/issues/456))
-- Development - DevOps 5.0 adaptation - AMI & OVA - Update certificates in the core configurer ([#448](https://github.com/wazuh/wazuh-virtual-machines/issues/448))
-- Development - DevOps 5.0 adaptation - AMI & OVA - Update indexer indices to remove ([#449](https://github.com/wazuh/wazuh-virtual-machines/issues/449))
+
+| Issue | Comment |
+| - | - |
+| [#883](https://github.com/wazuh/wazuh-virtual-machines/issues/883) | Error on AMI and OVA Build |
+| [#872](https://github.com/wazuh/wazuh-virtual-machines/issues/872) | Update deployment for Wazuh Indexer 5.0.0 RBAC (VMs) |
+| [#859](https://github.com/wazuh/wazuh-virtual-machines/issues/859) | Modify the Wazuh indexer heap size |
+| [#874](https://github.com/wazuh/wazuh-virtual-machines/pull/874) | Add new WF for changelog check |
+| [#844](https://github.com/wazuh/wazuh-virtual-machines/pull/844) | Change upload and download methods |
+| [#857](https://github.com/wazuh/wazuh-virtual-machines/issues/857) | Set authd password in agents installation |
+| [#813](https://github.com/wazuh/wazuh-virtual-machines/pull/813) | Change file and workflow names for PR revamp. |
+| [#820](https://github.com/wazuh/wazuh-virtual-machines/pull/820) | Changed runners to AWS CodeBuild for main branch |
+| [#779](https://github.com/wazuh/wazuh-virtual-machines/issues/779) | Update the deleted indexes in OVA and AMI builds |
+| [#679](https://github.com/wazuh/wazuh-virtual-machines/issues/679) | Change the destination path of the artifact_urls file in wazuh-virtual-machines |
+| [#688](https://github.com/wazuh/wazuh-virtual-machines/issues/688) | Update the hardware required for OVA and AMI 5.0.0 |
+| [#649](https://github.com/wazuh/wazuh-virtual-machines/pull/649) | Reverted PR 641. |
+| [#647](https://github.com/wazuh/wazuh-virtual-machines/issues/647) | Virtual machines - Ensure correct Wazuh manager certificates ownership |
+| [#640](https://github.com/wazuh/wazuh-virtual-machines/pull/640) | Change artifact suffix and prod and pre-prod urls |
+| [#635](https://github.com/wazuh/wazuh-virtual-machines/issues/635) | Wazuh virtual machines - Review and update the passwords tool's naming conventions |
+| [#631](https://github.com/wazuh/wazuh-virtual-machines/pull/631) | Updated wazuh-virtual-machines documentation config and tooling versions to meet new standards. |
+| [#584](https://github.com/wazuh/wazuh-virtual-machines/issues/584) | Decouple EC2 bare metal termination from GHA workflow in OVA build and monitor termination failures via EventBridge |
+| [#621](https://github.com/wazuh/wazuh-virtual-machines/pull/621) | Update artifact generation jobs to use wz-linux dedicated runner group |
+| [#599](https://github.com/wazuh/wazuh-virtual-machines/issues/599) | URL presigned file - Update the Wazuh virtual machines arctifact creation workflows |
+| [#569](https://github.com/wazuh/wazuh-virtual-machines/issues/569) | Development - Separate Agent/Manager - VMs - Add Wazuh agent clean up in the OVA `post configurer` module |
+| [#610](https://github.com/wazuh/wazuh-virtual-machines/issues/610) | Wazuh Manager/agent Separation - Breaking changes summary |
+| [#578](https://github.com/wazuh/wazuh-virtual-machines/issues/578) | Addapt Builder OVA and AMI to execute test WF |
+| [#564](https://github.com/wazuh/wazuh-virtual-machines/issues/564) | Development - Separate Agent/Manager - VMs - Update the Wazuh Manager path references to `/var/wazuh-manager/` |
+| [#548](https://github.com/wazuh/wazuh-virtual-machines/issues/548) | Adapt the integration test module |
+| [#549](https://github.com/wazuh/wazuh-virtual-machines/issues/549) | Duplicate AMI name in CreateImage in AWS EC2 |
+| [#553](https://github.com/wazuh/wazuh-virtual-machines/pull/553) | Change URL sign expiration time and add debug messages |
+| [#526](https://github.com/wazuh/wazuh-virtual-machines/issues/526) | Update the OVA and AMI workflow upload a latest arctifact in case of is_stage == false |
+| [#516](https://github.com/wazuh/wazuh-virtual-machines/issues/516) | Adapt password change in AMI build to new restrictions |
+| [#506](https://github.com/wazuh/wazuh-virtual-machines/issues/506) | ARM AMI - Update Wazuh AMI guides for ARM64 support |
+| [#510](https://github.com/wazuh/wazuh-virtual-machines/pull/510) | OVA composite names update |
+| [#503](https://github.com/wazuh/wazuh-virtual-machines/issues/503) | ARM AMI - Adapt Wazuh AMI generation code for ARM64 support |
+| [#451](https://github.com/wazuh/wazuh-virtual-machines/issues/451) | Development - DevOps 5.0 adaptation - AMI & OVA - Update the path to the development URL file in the build workflows |
+| [#450](https://github.com/wazuh/wazuh-virtual-machines/issues/450) | Development - DevOps 5.0 adaptation - AMI - Password tool development |
+| [#456](https://github.com/wazuh/wazuh-virtual-machines/issues/456) | Development - DevOps 5.0 adaptation - OVA - Adapt the uploading AWS S3 path for the OVA |
+| [#448](https://github.com/wazuh/wazuh-virtual-machines/issues/448) | Development - DevOps 5.0 adaptation - AMI & OVA - Update certificates in the core configurer |
+| [#449](https://github.com/wazuh/wazuh-virtual-machines/issues/449) | Development - DevOps 5.0 adaptation - AMI & OVA - Update indexer indices to remove |
+
+### Removed
+
+
+| Issue | Comment |
+| - | - |
+| [#544](https://github.com/wazuh/wazuh-virtual-machines/issues/544) | Removed obsolete OVA and AMI creation methods |
 
 ### Fixed
 
-- Unexpected failure when repository bump is executed and no changes are made ([#856](https://github.com/wazuh/wazuh-virtual-machines/issues/856))
-- Bumper script issue when the tag is set to false ([#826](https://github.com/wazuh/wazuh-virtual-machines/issues/826))
-- Error in OVA and AMI checks ([#787](https://github.com/wazuh/wazuh-virtual-machines/issues/787))
-- The AMI ARM build is failing when it fetches the manager package ([#744](https://github.com/wazuh/wazuh-virtual-machines/issues/744))
-- Bump PR not merged in either step despite workflow reporting success ([#670](https://github.com/wazuh/wazuh-virtual-machines/issues/670))
-- Unreachable AMI via SSH connection for AWS ([#634](https://github.com/wazuh/wazuh-virtual-machines/issues/634))
-- Fix check vulnerabilities ([#609](https://github.com/wazuh/wazuh-virtual-machines/pull/609))
-- Fix failing AMI `pre-configurer` tests ([#585](https://github.com/wazuh/wazuh-virtual-machines/issues/585))
-- AMI build upload GitHub workflow artifact fails due to duplicated name ([#550](https://github.com/wazuh/wazuh-virtual-machines/issues/550))
-- Failure when building AMI from the main branch ([#539](https://github.com/wazuh/wazuh-virtual-machines/issues/539))
-- Clean OVA files related to Cloud Init and Vagrant ([#519](https://github.com/wazuh/wazuh-virtual-machines/issues/519))
-- Addapt OVA generation fixes while generate vagrant resources ([#437](https://github.com/wazuh/wazuh-virtual-machines/issues/437))
-- OVA generation failed while creating the Vagrant resource ([#426](https://github.com/wazuh/wazuh-virtual-machines/issues/426))
 
-### Deleted
+| Issue | Comment |
+| - | - |
+| [#856](https://github.com/wazuh/wazuh-virtual-machines/issues/856) | Unexpected failure when repository bump is executed and no changes are made |
+| [#826](https://github.com/wazuh/wazuh-virtual-machines/issues/826) | Bumper script issue when the tag is set to false |
+| [#787](https://github.com/wazuh/wazuh-virtual-machines/issues/787) | Error in OVA and AMI checks |
+| [#744](https://github.com/wazuh/wazuh-virtual-machines/issues/744) | The AMI ARM build is failing when it fetches the manager package |
+| [#670](https://github.com/wazuh/wazuh-virtual-machines/issues/670) | Bump PR not merged in either step despite workflow reporting success |
+| [#634](https://github.com/wazuh/wazuh-virtual-machines/issues/634) | Unreachable AMI via SSH connection for AWS |
+| [#609](https://github.com/wazuh/wazuh-virtual-machines/pull/609) | Fix check vulnerabilities |
+| [#585](https://github.com/wazuh/wazuh-virtual-machines/issues/585) | Fix failing AMI `pre-configurer` tests |
+| [#550](https://github.com/wazuh/wazuh-virtual-machines/issues/550) | AMI build upload GitHub workflow artifact fails due to duplicated name |
+| [#539](https://github.com/wazuh/wazuh-virtual-machines/issues/539) | Failure when building AMI from the main branch |
+| [#519](https://github.com/wazuh/wazuh-virtual-machines/issues/519) | Clean OVA files related to Cloud Init and Vagrant |
+| [#437](https://github.com/wazuh/wazuh-virtual-machines/issues/437) | Addapt OVA generation fixes while generate vagrant resources |
+| [#426](https://github.com/wazuh/wazuh-virtual-machines/issues/426) | OVA generation failed while creating the Vagrant resource |
 
-- Removed obsolete OVA and AMI creation methods ([#544](https://github.com/wazuh/wazuh-virtual-machines/issues/544))
-
-## Prior version
+## Prior versions
 
 - []()


### PR DESCRIPTION
## Description

As part of the wazuh-virtual-machines objective, this PR updates the CHANGELOG.md format for the 5.0.0 branch, as described in #3647.

Changes applied:

Removed the leading # Change Log title and the "All notable changes..." line. The file now starts directly with ## [v5.0.0].
Converted each section (Added, Changed, Removed, Fixed) from a bullet list to a table, with the issue/PR link in the first column and the description in the second.
Renamed ## Prior version to ## Prior versions, keeping the existing - placeholder as requested, since this is the first version using this format and has no prior versions to reference yet.