### PR TITLE
Test: invalid changelog entry format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,6 @@
 
 | Issue | Comment |
 | - | - |
-- Test entry with wrong format (issue 9999)
 | This is not a valid entry format | Missing issue link entirely |
 | [#896](https://github.com/wazuh/wazuh-docker/issues/896) | Fixed changelog check workflow to accept Prior versions entries |
 | [#856](https://github.com/wazuh/wazuh-virtual-machines/issues/856) | Unexpected failure when repository bump is executed and no changes are made |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@
 
 | Issue | Comment |
 | - | - |
+- Test entry with wrong format (issue 9999)
 | [#896](https://github.com/wazuh/wazuh-docker/issues/896) | Fixed changelog check workflow to accept Prior versions entries |
 | [#856](https://github.com/wazuh/wazuh-virtual-machines/issues/856) | Unexpected failure when repository bump is executed and no changes are made |
 | [#826](https://github.com/wazuh/wazuh-virtual-machines/issues/826) | Bumper script issue when the tag is set to false |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 
 | Issue | Comment |
 | - | - |
-- Test entry with wrong format (issue 9999)
+| This is not a valid entry format | Missing issue link entirely |
 | [#896](https://github.com/wazuh/wazuh-docker/issues/896) | Fixed changelog check workflow to accept Prior versions entries |
 | [#856](https://github.com/wazuh/wazuh-virtual-machines/issues/856) | Unexpected failure when repository bump is executed and no changes are made |
 | [#826](https://github.com/wazuh/wazuh-virtual-machines/issues/826) | Bumper script issue when the tag is set to false |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 | Issue | Comment |
 | - | - |
 - Test entry with wrong format (issue 9999)
+| This is not a valid entry format | Missing issue link entirely |
 | [#896](https://github.com/wazuh/wazuh-docker/issues/896) | Fixed changelog check workflow to accept Prior versions entries |
 | [#856](https://github.com/wazuh/wazuh-virtual-machines/issues/856) | Unexpected failure when repository bump is executed and no changes are made |
 | [#826](https://github.com/wazuh/wazuh-virtual-machines/issues/826) | Bumper script issue when the tag is set to false |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 
 | Issue | Comment |
 | - | - |
-| This is not a valid entry format | Missing issue link entirely |
+- Test entry with wrong format (issue 9999)
 | [#896](https://github.com/wazuh/wazuh-docker/issues/896) | Fixed changelog check workflow to accept Prior versions entries |
 | [#856](https://github.com/wazuh/wazuh-virtual-machines/issues/856) | Unexpected failure when repository bump is executed and no changes are made |
 | [#826](https://github.com/wazuh/wazuh-virtual-machines/issues/826) | Bumper script issue when the tag is set to false |


### PR DESCRIPTION
## Description

Test PR only, not meant to be merged. Used to validate the fix in #3657.


## Related issue

https://github.com/wazuh/wazuh-virtual-machines/pull/896