### PR TITLE
Add early check for duplicate AMI name before instance provisioning

### DIFF
--- a/.github/workflows/5_AMI_builder.yaml
+++ b/.github/workflows/5_AMI_builder.yaml
@@ -241,6 +241,17 @@ jobs:
           echo WAZUH_MINOR=$WAZUH_MINOR >> $GITHUB_ENV
           echo WAZUH_REVISION=$WAZUH_REVISION >> $GITHUB_ENV
           echo ARCH_SUFFIX=$ARCH_SUFFIX >> $GITHUB_ENV
+      - name: Check if AMI name is already in use
+        run: |
+          EXISTING_AMI_ID=$(aws ec2 describe-images \
+            --owners self \
+            --filters "Name=name,Values=${{ env.AMI_NAME }}" \
+            --query 'Images[0].ImageId' --output text)
+          if [ "$EXISTING_AMI_ID" != "None" ] && [ -n "$EXISTING_AMI_ID" ]; then
+            echo "::error::AMI name ${{ env.AMI_NAME }} is already in use by $EXISTING_AMI_ID. Aborting before provisioning the base instance."
+            exit 1
+          fi
+          echo "AMI name ${{ env.AMI_NAME }} is available."
 
       - name: Install and set allocator requirements
         run: |


### PR DESCRIPTION
## Related issue:

https://github.com/wazuh/wazuh-virtual-machines/issues/903

## Description 

This PR implements only the early duplicate-name check described in
issue #903 (point 1 of the proposal): a new step, `Check if AMI name is
already in use`, added right after the AMI name is computed and before
the base instance is provisioned (~10 minutes). If the name already
exists in AWS, the workflow now fails in seconds with a clear error,
instead of waiting for the late `InvalidAMIName.Duplicate` error from
`aws ec2 create-image`.