### PR TITLE
Activate buildspec-override for a complete Python 3.12 on CodeBuild

### DIFF
--- a/.github/workflows/4_AMI_builder.yaml
+++ b/.github/workflows/4_AMI_builder.yaml
@@ -62,7 +62,9 @@ permissions:
 
 jobs:
   Build_AMI:
-    runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
     steps:
       - name: View parameters
         run: echo "${{ toJson(inputs) }}"

--- a/.github/workflows/4_OVA_builder.yaml
+++ b/.github/workflows/4_OVA_builder.yaml
@@ -77,7 +77,9 @@ permissions:
 
 jobs:
   build_and_run:
-    runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
     steps:
       - name: View parameters
         run: echo "${{ toJson(inputs) }}"

--- a/.github/workflows/5_AMI_builder.yaml
+++ b/.github/workflows/5_AMI_builder.yaml
@@ -148,7 +148,9 @@ permissions:
 
 jobs:
   Build_AMI:
-    runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
     strategy:
       fail-fast: false
       matrix:
@@ -422,7 +424,9 @@ jobs:
   collect_ami_ids:
     needs: Build_AMI
     if: always() && inputs.is_pr_check == true
-    runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
     outputs:
       ami_id_amd64: ${{ steps.get_ids.outputs.ami_id_amd64 }}
       ami_id_arm64: ${{ steps.get_ids.outputs.ami_id_arm64 }}
@@ -452,7 +456,9 @@ jobs:
   update_os_yml:
     needs: Build_AMI
     if: always() && inputs.is_stage == true && (inputs.purpose == 'release' || inputs.purpose == 'pre-release')
-    runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
     steps:
       - name: Checkout wazuh/wazuh-virtual-machines repository
         uses: actions/checkout@v6

--- a/.github/workflows/5_OVA_builder.yaml
+++ b/.github/workflows/5_OVA_builder.yaml
@@ -125,7 +125,9 @@ permissions:
 
 jobs:
   build:
-    runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
     outputs:
       ova_matrix: ${{ steps.set_filenames.outputs.ova_matrix }}
       box_matrix: ${{ steps.set_filenames.outputs.box_matrix }}
@@ -376,7 +378,9 @@ jobs:
 
   upload_ova:
     needs: build
-    runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
     strategy:
       matrix:
         include: ${{ fromJson(needs.build.outputs.ova_matrix) }}
@@ -410,7 +414,9 @@ jobs:
 
   upload_box:
     needs: build
-    runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
     strategy:
       matrix:
         include: ${{ fromJson(needs.build.outputs.box_matrix) }}
@@ -445,7 +451,9 @@ jobs:
   cleanup:
     needs: [build, upload_ova, upload_box]
     if: always() && needs.build.result != 'skipped'
-    runs-on: codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+    runs-on:
+      - codebuild-github-actions-codebuild-runner-devops-amd-${{ github.run_id }}-${{ github.run_attempt }}
+      - buildspec-override:true
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#932](https://github.com/wazuh/wazuh-virtual-machines/pull/932) | Activate buildspec-override for a complete Python 3.12 on CodeBuild |
 | [#912](https://github.com/wazuh/wazuh-virtual-machines/issues/912) | Change Codebuild runners to Github runners |
 | [#883](https://github.com/wazuh/wazuh-virtual-machines/issues/883) | Error on AMI and OVA Build |
 | [#872](https://github.com/wazuh/wazuh-virtual-machines/issues/872) | Update deployment for Wazuh Indexer 5.0.0 RBAC (VMs) |

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,5 @@
+version: 0.2
+phases:
+  install:
+    runtime-versions:
+      python: 3.12


### PR DESCRIPTION
Related to https://github.com/wazuh/wazuh-automation/issues/3722

Adds a repo-level `buildspec.yml` requesting Python 3.12 via `runtime-versions`, and enables `buildspec-override:true` on the jobs that install the Allocator in `4_AMI_builder.yaml`, `5_AMI_builder.yaml`, `5_OVA_builder.yaml`, and `4_OVA_builder.yaml`.
