### PR TITLE
Migrate Allocator invocation to installable Python package

### DIFF
--- a/.github/workflows/4_AMI_builder.yaml
+++ b/.github/workflows/4_AMI_builder.yaml
@@ -122,12 +122,12 @@ jobs:
 
       - name: Install and set allocator requirements
         run: |
-          python3 -m pip install -r wazuh-automation/deployability/deps/requirements.txt
+          python3 -m pip install ./wazuh-automation/deployability/modules/allocation
 
       - name: Execute allocator module that will create the base instance
         id: alloc_vm_ami
         run: |
-          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
+          wazuh-allocator --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
             --track-output ${{ env.ALLOCATOR_PATH }}/track.yml --inventory-output ${{ env.ALLOCATOR_PATH }}/inventory.yml --instance-name gha_${{ github.run_id }}_ami_build \
             --label-team devops --label-termination-date 1d
           sed -n '/hosts:/,/^[^ ]/p' ${{ env.ALLOCATOR_PATH }}/inventory.yml | grep "ansible_" | sed 's/^[ ]*//g' > ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Delete allocated VM
         if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.destroy == true
-        run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output ${{ env.ALLOCATOR_PATH }}/track.yml
+        run: wazuh-allocator --action delete --track-output ${{ env.ALLOCATOR_PATH }}/track.yml
 
       - name: Compress Allocator directory
         id: generate_artifacts

--- a/.github/workflows/4_OVA_builder.yaml
+++ b/.github/workflows/4_OVA_builder.yaml
@@ -156,12 +156,12 @@ jobs:
 
       - name: Install and set allocator requirements
         run: |
-          pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+          pip3 install ./wazuh-automation/deployability/modules/allocation
 
       - name: Execute allocator module that will create the base instance
         id: alloc_vm
         run: |
-          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size ${{ env.INSTANCE_TYPE }} --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
+          wazuh-allocator --action create --provider aws --size ${{ env.INSTANCE_TYPE }} --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
             --track-output ${{ env.ALLOCATOR_PATH }}/track.yml --inventory-output ${{ env.ALLOCATOR_PATH }}/inventory.yml --instance-name gha_${{ github.run_id }}_ova_build \
             --label-team devops --label-termination-date 1d
           sed -n '/hosts:/,/^[^ ]/p' ${{ env.ALLOCATOR_PATH }}/inventory.yml | grep "ansible_" | sed 's/^[ ]*//g' > ${{ env.ALLOCATOR_PATH }}/inventory_mod.yml
@@ -229,4 +229,4 @@ jobs:
 
       - name: Delete allocated VM
         if: always() && steps.alloc_vm.outcome == 'success'
-        run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output ${{ env.ALLOCATOR_PATH }}/track.yml
+        run: wazuh-allocator --action delete --track-output ${{ env.ALLOCATOR_PATH }}/track.yml

--- a/.github/workflows/5_AMI_builder.yaml
+++ b/.github/workflows/5_AMI_builder.yaml
@@ -244,12 +244,12 @@ jobs:
 
       - name: Install and set allocator requirements
         run: |
-          pip install -r wazuh-automation/deployability/deps/requirements.txt
+          pip install ./wazuh-automation/deployability/modules/allocation
 
       - name: Execute allocator module that will create the base instance
         id: alloc_vm_ami
         run: |
-          python wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
+          wazuh-allocator --action create --provider aws --size large --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
             --track-output ${{ env.ALLOCATOR_PATH }}/track.yml --inventory-output ${{ env.ALLOCATOR_PATH }}/inventory.yml --instance-name gha_${{ github.run_id }}_ami_build \
             --label-team devops --label-termination-date 1d
           INSTANCE_ID=$(yq '.all.hosts | keys | .[0]' ${{ env.ALLOCATOR_PATH }}/inventory.yml)
@@ -406,7 +406,7 @@ jobs:
 
       - name: Delete allocated VM
         if: always() && steps.alloc_vm_ami.outcome == 'success' && inputs.destroy == true
-        run: python3 wazuh-automation/deployability/modules/allocation/main.py --action delete --track-output ${{ env.ALLOCATOR_PATH }}/track.yml
+        run: wazuh-allocator --action delete --track-output ${{ env.ALLOCATOR_PATH }}/track.yml
 
       - name: Compress Allocator directory
         id: generate_artifacts

--- a/.github/workflows/5_OVA_builder.yaml
+++ b/.github/workflows/5_OVA_builder.yaml
@@ -219,12 +219,12 @@ jobs:
 
       - name: Install and set allocator requirements
         run: |
-          pip3 install -r wazuh-automation/deployability/deps/requirements.txt
+          pip3 install ./wazuh-automation/deployability/modules/allocation
 
       - name: Execute allocator module that will create the base instance
         id: alloc_vm_ova
         run: |
-          python3 wazuh-automation/deployability/modules/allocation/main.py --action create --provider aws --size ${{ env.INSTANCE_TYPE }} --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
+          wazuh-allocator --action create --provider aws --size ${{ env.INSTANCE_TYPE }} --composite-name ${{ env.COMPOSITE_NAME }} --working-dir ${{ env.ALLOCATOR_PATH }} \
             --track-output ${{ env.ALLOCATOR_PATH }}/track.yml --inventory-output ${{ env.ALLOCATOR_PATH }}/inventory.yml --instance-name gha_${{ github.run_id }}_ova_build \
             --label-team devops --label-termination-date 1d --custom-tags "purpose:build-ova,WorkflowRun:${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 

--- a/.github/workflows/5_test-vm.yaml
+++ b/.github/workflows/5_test-vm.yaml
@@ -309,7 +309,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'wazuh-automation/integration-test-module/requirements.txt'
 
@@ -822,7 +822,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'wazuh-automation/integration-test-module/requirements.txt'
 

--- a/.github/workflows/5_test-vm.yaml
+++ b/.github/workflows/5_test-vm.yaml
@@ -549,7 +549,7 @@ jobs:
 
       - name: Install allocator dependencies
         run: |
-          pip install -r wazuh-automation/deployability/deps/requirements.txt
+          pip install ./wazuh-automation/deployability/modules/allocation
           pip install ansible pyyaml
       
       - name: Install yq
@@ -626,7 +626,7 @@ jobs:
           INSTANCE_NAME="gha_${{ github.run_id }}_ova_test"
 
           # Run allocation module to create EC2 instance
-          python wazuh-automation/deployability/modules/allocation/main.py \
+          wazuh-allocator \
             --action create \
             --provider aws \
             --size metal \
@@ -974,10 +974,10 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
-        run: pip install -r wazuh-automation/deployability/deps/requirements.txt
+        run: pip install ./wazuh-automation/deployability/modules/allocation
 
       - name: Download allocator working directory
         id: download-workdir
@@ -1033,7 +1033,7 @@ jobs:
           echo ""
           echo "Terminating allocator instance..."
 
-          python wazuh-automation/deployability/modules/allocation/main.py \
+          wazuh-allocator \
             --action delete \
             --track-output ${TRACK_FILE}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#933](https://github.com/wazuh/wazuh-virtual-machines/pull/933) | Migrate Allocator invocation to installable Python package |
 | [#912](https://github.com/wazuh/wazuh-virtual-machines/issues/912) | Change Codebuild runners to Github runners |
 | [#883](https://github.com/wazuh/wazuh-virtual-machines/issues/883) | Error on AMI and OVA Build |
 | [#872](https://github.com/wazuh/wazuh-virtual-machines/issues/872) | Update deployment for Wazuh Indexer 5.0.0 RBAC (VMs) |


### PR DESCRIPTION
Related to https://github.com/wazuh/internal-devel-requests/issues/5888

## Changes
- \`4_AMI_builder.yaml\`: requirements install + create/delete invocation.
- \`4_OVA_builder.yaml\`: requirements install + create/delete invocation.
- \`5_OVA_builder.yaml\`: requirements install + create invocation. 
- \`5_test-vm.yaml\`: requirements install + create/delete invocation in both \`ova-setup\` and \`ova-cleanup\` jobs. Also bumped \`ova-cleanup\`'s Python from 3.10 to 3.12, required by the new package (\`requires-python >=3.12,<3.13\`).

## Not included yet
- \`5_AMI_builder.yaml\` — blocked by #917, which inserts a new step right before the affected lines. 