### PR TITLE
regenerate the local agent's client.keys per instance at first boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#931](https://github.com/wazuh/wazuh-virtual-machines/issues/931) | Regenerate the local agent's client.keys per instance at first boot |
 | [#919](https://github.com/wazuh/wazuh-virtual-machines/pull/919) | Report skipped bumps in the repository bumper workflow |
 | [#896](https://github.com/wazuh/wazuh-virtual-machines/pull/896) | Fixed changelog check workflow to accept Prior versions entries |
 | [#856](https://github.com/wazuh/wazuh-virtual-machines/issues/856) | Unexpected failure when repository bump is executed and no changes are made |

--- a/configurer/ami/ami_post_configurer/wazuh-ami-customizer.py
+++ b/configurer/ami/ami_post_configurer/wazuh-ami-customizer.py
@@ -23,6 +23,7 @@ WAZUH_WARNING_SCRIPT = Path("/etc/profile.d/wazuh-debug-warning.sh")
 # this file. The same password must be distributed to the agent so it can enroll against the manager.
 WAZUH_MANAGER_AUTHD_PASS_FILE = "/var/wazuh-manager/etc/authd.pass"
 WAZUH_AGENT_AUTHD_PASS_FILE = "/var/ossec/etc/authd.pass"
+WAZUH_AGENT_CLIENT_KEYS_FILE = "/var/ossec/etc/client.keys"
 AUTHD_PASS_MAX_RETRIES = 12
 AUTHD_PASS_WAIT_TIME = 5
 
@@ -178,6 +179,29 @@ def remove_certificates() -> None:
         raise RuntimeError("Error removing existing certificates")
 
     logger.debug("Existing certificates removed")
+
+
+def remove_client_keys() -> None:
+    """
+    Removes the local agent's baked-in client.keys.
+
+    The local agent enrolls against the manager on the same instance during image build,
+    producing a client.keys file that would be identical across every instance launched from
+    this image. It is removed here so the agent re-enrolls and gets a unique one on first boot,
+    the same way the authd password is rotated per instance.
+
+    Returns:
+        None
+    """
+
+    logger.debug("Removing existing client.keys...")
+    command = f"rm -f {WAZUH_AGENT_CLIENT_KEYS_FILE}"
+    _, error_output = exec_command(command=command)
+    if error_output:
+        logger.error(f"Error removing client.keys: {error_output}")
+        raise RuntimeError("Error removing client.keys")
+
+    logger.debug("Existing client.keys removed")
 
 
 def create_certificates() -> None:
@@ -561,6 +585,7 @@ if __name__ == "__main__":
         stop_components_services()
         remove_certificates()
         create_certificates()
+        remove_client_keys()
         start_components_services()
         stop_service("wazuh-dashboard")
         change_passwords()

--- a/configurer/ova/ova_post_configurer/ova_post_configurer.py
+++ b/configurer/ova/ova_post_configurer/ova_post_configurer.py
@@ -210,9 +210,11 @@ def steps_clean() -> None:
     1. Removes the file `/securityadmin_demo.sh`.
     2. Removes the manager's self-signed remoted certificate baked in at image build time
        (regenerated per instance by wazuh-starter on first boot).
-    3. Cleans all cached data for the `yum` package manager.
-    4. Reloads the systemd manager configuration.
-    5. Clears the current user's bash history.
+    3. Removes the local agent's baked-in client.keys (regenerated per instance by
+       wazuh-starter on first boot, via re-enrollment).
+    4. Cleans all cached data for the `yum` package manager.
+    5. Reloads the systemd manager configuration.
+    6. Clears the current user's bash history.
 
     Returns:
         None
@@ -223,6 +225,10 @@ def steps_clean() -> None:
         # Shipping it would make every VM deployed from this OVA share the same certificate/key, so it
         # is removed here and regenerated per instance by wazuh-starter on first boot.
         "rm -f /var/wazuh-manager/etc/certs/remoted.pem /var/wazuh-manager/etc/certs/remoted-key.pem",
+        # The local agent enrolled against the manager on this same instance at image build time,
+        # producing a client.keys that would be identical across every VM deployed from this OVA.
+        # Removed here so the agent re-enrolls and gets a unique one per instance on first boot.
+        "rm -f /var/ossec/etc/client.keys",
         "yum clean all",
         "systemctl daemon-reload",
         "cat /dev/null > ~/.bash_history && history -c",

--- a/configurer/ova/ova_post_configurer/scripts/wazuh-starter/wazuh-starter.sh
+++ b/configurer/ova/ova_post_configurer/scripts/wazuh-starter/wazuh-starter.sh
@@ -17,6 +17,7 @@ wazuh_agent_authd_pass="/var/ossec/etc/authd.pass"
 wazuh_manager_certs_dir="/var/wazuh-manager/etc/certs"
 wazuh_manager_remoted_cert="${wazuh_manager_certs_dir}/remoted.pem"
 wazuh_manager_remoted_key="${wazuh_manager_certs_dir}/remoted-key.pem"
+wazuh_agent_client_keys="/var/ossec/etc/client.keys"
 authd_pass_max_retries=12
 authd_pass_wait_time=5
 
@@ -134,6 +135,13 @@ function regenerate_remoted_certificate() {
   logger "Manager remoted certificate regenerated successfully"
 }
 
+function remove_client_keys() {
+  # Remove the local agent's baked-in client.keys so it re-enrolls and gets a unique one on
+  # this instance. The rm guards against an image built before the cleanup removed it.
+  logger "Removing pre-generated client.keys to force agent re-enrollment on first boot"
+  rm -f "${wazuh_agent_client_keys}"
+}
+
 function clean_configuration(){
   logger "Cleaning configuration files"
   eval "rm -rf /var/log/wazuh-starter.log"
@@ -149,6 +157,7 @@ logger "Starting Wazuh services in order"
 
 rotate_authd_password
 regenerate_remoted_certificate
+remove_client_keys
 
 starter_service wazuh-indexer
 verify_indexer

--- a/tests/test_configurer/test_ova/test_ova_post_configurer/test_ova_post_configurer.py
+++ b/tests/test_configurer/test_ova/test_ova_post_configurer/test_ova_post_configurer.py
@@ -258,6 +258,7 @@ def test_steps_clean(mock_run_command):
         [
             "rm -f /securityadmin_demo.sh",
             "rm -f /var/wazuh-manager/etc/certs/remoted.pem /var/wazuh-manager/etc/certs/remoted-key.pem",
+            "rm -f /var/ossec/etc/client.keys",
             "yum clean all",
             "systemctl daemon-reload",
             "cat /dev/null > ~/.bash_history && history -c",


### PR DESCRIPTION
## Related issue #931 

## Description 

- **AMI** (`wazuh-ami-customizer.py`): added `remove_client_keys()`,
  called between certificate regeneration and starting services.
- **OVA** (`ova_post_configurer.py`): added `client.keys` removal to
  `steps_clean()`, alongside the existing `remoted.*` cleanup.
- **OVA** (`wazuh-starter.sh`): added `remove_client_keys()`, called
  alongside `rotate_authd_password`/`regenerate_remoted_certificate`
  before services start.

No explicit regeneration command is needed here (unlike the self-signed
`remoted` certificate): the agent already re-enrolls automatically
against authd on startup using the rotated per-instance password,
producing a fresh `client.keys` as a side effect of that existing flow.

## Validation

- `hatch`-declared test suites pass: OVA post-configurer (20/20, 99%
  coverage) and AMI post/pre-configurer (82/82). `wazuh-ami-customizer.py`
  has 0% unit coverage by design — same as before this change — since it
  only runs on a real instance's first boot, not under pytest.
- Pending: live AMI/OVA deployment evidence confirming two instances
  from the same image get different `client.keys` (task 3 of #931).