### PR TITLE
fix: ignore ICMP redirects and add network diagnostics before VPN wait

### DIFF
--- a/.github/workflows/4_OVA_builder.yaml
+++ b/.github/workflows/4_OVA_builder.yaml
@@ -129,6 +129,11 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y openvpn openvpn-systemd-resolved
+          # See wazuh/wazuh-virtual-machines#946: a spurious ICMP Redirect from
+          # the local gateway can divert traffic to the VPN server away from
+          # the tunnel. Redirects are ignored to prevent that from happening.
+          sudo sysctl -w net.ipv4.conf.all.accept_redirects=0
+          sudo sysctl -w net.ipv4.conf.default.accept_redirects=0
           echo "${{ secrets.CI_VPN_GITHUB }}" > vpn.ovpn
           sudo openvpn --config "vpn.ovpn" --daemon
 
@@ -137,6 +142,10 @@ jobs:
         timeout-minutes: 10
         run: |
           while ! ping -c2 10.10.0.252; do
+            echo "::group::Network diagnostics (VPN ping failed)"
+            ip route show
+            sudo systemctl status openvpn* --no-pager || true
+            echo "::endgroup::"
             sudo kill -9 `pidof openvpn`;
             sudo openvpn --config "vpn.ovpn" --daemon;
             sleep 30;

--- a/.github/workflows/4_OVA_builder.yaml
+++ b/.github/workflows/4_OVA_builder.yaml
@@ -141,7 +141,9 @@ jobs:
         id: vpn_connected
         timeout-minutes: 10
         run: |
-          while ! ping -c2 10.10.0.252; do
+          # 10.10.0.1 is the VPN server itself, not an unrelated MacStadium
+          # host (see wazuh/wazuh-virtual-machines#946).
+          while ! ping -c2 10.10.0.1; do
             echo "::group::Network diagnostics (VPN ping failed)"
             ip route show
             sudo systemctl status openvpn* --no-pager || true


### PR DESCRIPTION
  - The OVA builder workflow failed at "Wait for a VPN connection" due to a spurious ICMP Redirect diverting VPN traffic away from the tun interface (see #946).
  - Disable accept_redirects before starting OpenVPN and add network diagnostics to the retry loop for future failures.
